### PR TITLE
feat: enhanced procedural generation system (#1)

### DIFF
--- a/src/components/MainEditor.tsx
+++ b/src/components/MainEditor.tsx
@@ -15,6 +15,7 @@ import WeatherSettingsModal from './modals/WeatherSettingsModal';
 import ConfirmDialog from './modals/ConfirmDialog';
 import KeyboardShortcutsModal from './modals/KeyboardShortcutsModal';
 import EncounterTableEditorModal from './modals/EncounterTableEditorModal';
+import LandmarkTableEditorModal from './modals/LandmarkTableEditorModal';
 import EncounterTemplateLibrary from './modals/EncounterTemplateLibrary';
 import RegionManagerModal from './modals/RegionManagerModal';
 import CommandPalette from './CommandPalette';
@@ -47,6 +48,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
   const [showKeyboardShortcuts, setShowKeyboardShortcuts] = useState(false);
   const [showEncounterTableEditor, setShowEncounterTableEditor] = useState(false);
+  const [showLandmarkTableEditor, setShowLandmarkTableEditor] = useState(false);
   const [showTemplateLibrary, setShowTemplateLibrary] = useState(false);
   const [showRegionManager, setShowRegionManager] = useState(false);
 
@@ -294,7 +296,10 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
 
         <div className="toolbar-right">
           <button className="btn btn-secondary" onClick={() => setShowEncounterTableEditor(true)}>
-            <Icon name="sword" size={16} /> Tables
+            <Icon name="sword" size={16} /> Encounters
+          </button>
+          <button className="btn btn-secondary" onClick={() => setShowLandmarkTableEditor(true)}>
+            <Icon name="pin" size={16} /> Landmarks
           </button>
           <button className="btn btn-secondary" onClick={() => setShowTemplateLibrary(true)}>
             <Icon name="sparkle" size={16} /> Templates
@@ -366,6 +371,9 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
       )}
       {showEncounterTableEditor && (
         <EncounterTableEditorModal onClose={() => setShowEncounterTableEditor(false)} />
+      )}
+      {showLandmarkTableEditor && (
+        <LandmarkTableEditorModal onClose={() => setShowLandmarkTableEditor(false)} />
       )}
       {showTemplateLibrary && (
         <EncounterTemplateLibrary onClose={() => setShowTemplateLibrary(false)} />

--- a/src/components/player/PlayerHexGrid.tsx
+++ b/src/components/player/PlayerHexGrid.tsx
@@ -152,6 +152,65 @@ function PlayerHexGrid({ campaign, selectedHexKey, onHexSelect, onHexDeselect }:
       }
     }
 
+    // CONNECTION PASS: Draw rivers and roads (visible on discovered/cleared hexes)
+    if (zoomLevel >= 0.25) {
+      for (let q = 0; q < campaign.gridWidth; q++) {
+        for (let r = 0; r < campaign.gridHeight; r++) {
+          const key = `${q},${r}`;
+          const hex = campaign.hexes[key];
+          if (!hex?.connections) continue;
+          if (hex.status === 'undiscovered') continue;
+          const coord: HexCoordinate = { q, r };
+          const center = hexCenter(coord);
+          const points = hexPoints(center, HEX_SIZE);
+
+          // Draw rivers (blue curved lines)
+          if (hex.connections.rivers.length > 0) {
+            ctx.strokeStyle = '#4a9eff';
+            ctx.lineWidth = 2;
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+
+            for (const edge of hex.connections.rivers) {
+              const p1 = points[edge];
+              const p2 = points[(edge + 1) % 6];
+              const edgeMidX = (p1.x + p2.x) / 2;
+              const edgeMidY = (p1.y + p2.y) / 2;
+
+              ctx.beginPath();
+              ctx.moveTo(edgeMidX, edgeMidY);
+              const cpX = center.x + (edgeMidX - center.x) * 0.3;
+              const cpY = center.y + (edgeMidY - center.y) * 0.3;
+              ctx.quadraticCurveTo(cpX, cpY, center.x, center.y);
+              ctx.stroke();
+            }
+          }
+
+          // Draw roads (brown dashed lines)
+          if (hex.connections.roads.length > 0 && zoomLevel >= 0.40) {
+            ctx.strokeStyle = '#8B7355';
+            ctx.lineWidth = 1.5;
+            ctx.lineCap = 'round';
+            ctx.setLineDash([3, 3]);
+
+            for (const edge of hex.connections.roads) {
+              const p1 = points[edge];
+              const p2 = points[(edge + 1) % 6];
+              const edgeMidX = (p1.x + p2.x) / 2;
+              const edgeMidY = (p1.y + p2.y) / 2;
+
+              ctx.beginPath();
+              ctx.moveTo(edgeMidX, edgeMidY);
+              ctx.lineTo(center.x, center.y);
+              ctx.stroke();
+            }
+
+            ctx.setLineDash([]);
+          }
+        }
+      }
+    }
+
     // PASS 2: Region borders
     for (const region of regionAdapters) {
       if (region.hexKeys.length === 0) continue;

--- a/src/services/playerViewFilter.ts
+++ b/src/services/playerViewFilter.ts
@@ -1,6 +1,6 @@
 // Player View Filter - Strips DM-only data from campaign for player consumption
 
-import type { Campaign, Hex, TerrainType, HexCoordinate, DiscoveryStatus } from '../types';
+import type { Campaign, Hex, TerrainType, HexCoordinate, DiscoveryStatus, HexConnections } from '../types';
 import type { TimeWeatherState } from '../types/Weather';
 import type { MarkerType, HexMarker } from '../types/Markers';
 
@@ -15,6 +15,8 @@ export interface PlayerHex {
   npcNames: string[];
   // Markers (visual only)
   markers?: HexMarker[];
+  // River and road connections (map features, not DM secrets)
+  connections?: HexConnections;
 }
 
 // Player-safe region data
@@ -82,7 +84,8 @@ function filterHexForPlayer(hex: Hex): PlayerHex {
     status: hex.status,
     locationNames: [],
     npcNames: [],
-    markers: hex.markers?.filter(m => m.isVisible)
+    markers: hex.markers?.filter(m => m.isVisible),
+    connections: hex.connections
   };
 
   // Only include content names for discovered/cleared hexes

--- a/src/types/Campaign.ts
+++ b/src/types/Campaign.ts
@@ -3,6 +3,7 @@
 import { TimeWeatherState, DEFAULT_WEATHER, DEFAULT_TIME, CalendarSystem } from './Weather';
 import { CALENDAR_PRESETS } from '../data/calendars';
 import { HexMarker, MarkerType, DEFAULT_MARKER_TYPES } from './Markers';
+import { DEFAULT_EXPANDED_ENCOUNTER_TABLES, DEFAULT_LANDMARK_TABLES } from '../data/generatorTables';
 
 export interface Campaign {
   id: string;
@@ -221,7 +222,7 @@ export function createCampaign(name: string, gridWidth: number, gridHeight: numb
     gridHeight: Math.min(gridHeight, 50),
     hexes: {},
     terrainTypes: DEFAULT_TERRAIN_TYPES,
-    encounterTables: DEFAULT_ENCOUNTER_TABLES,
+    encounterTables: DEFAULT_EXPANDED_ENCOUNTER_TABLES,
     createdAt: new Date().toISOString(),
     modifiedAt: new Date().toISOString(),
     timeWeather: createDefaultTimeWeather(),
@@ -230,7 +231,7 @@ export function createCampaign(name: string, gridWidth: number, gridHeight: numb
     bookmarkedHexes: [],
     regions: [],
     generationConfig: createDefaultGenerationConfig(),
-    landmarkTables: []
+    landmarkTables: DEFAULT_LANDMARK_TABLES
   };
 }
 


### PR DESCRIPTION
## Summary

Completes the Enhanced Procedural Generation System requested in #1. The core implementation was landed in `9d8a5f9`; this PR adds the remaining integration work:

- **Landmark Table Editor**: Wire `LandmarkTableEditorModal` into the MainEditor toolbar (separate "Encounters" and "Landmarks" buttons)
- **Player View Connections**: Pass `HexConnections` (rivers/roads) through `playerViewFilter.ts` to the player view, and render them in `PlayerHexGrid.tsx` with matching styles (blue curved rivers, brown dashed roads)
- **Expanded Default Tables**: New campaigns now use the full 10-terrain encounter and landmark tables from `generatorTables.ts` instead of the old 3-terrain defaults

### Full feature set delivered across both commits:
- Seeded PRNG (`rng.ts` — mulberry32, deterministic generation)
- Biome-aware terrain generation (seed-and-grow with adjacency affinity)
- Configurable generation parameters (seed, clustering, variety, encounter/landmark density)
- Expanded encounter tables (10 terrain types, 3-5 entries each)
- Landmark/POI generation with editable tables
- River networks (greedy downhill walk from mountains)
- Road networks (A* pathfinding between landmarks)
- 218 tests passing

## Test plan

- [x] `npx tsc --noEmit` — type check passes
- [x] `npx vitest run` — all 218 tests pass (rng, generator, generatorTables, playerViewFilter, campaign migration)
- [ ] Manual: Open Landmarks toolbar button, verify LandmarkTableEditorModal opens
- [ ] Manual: Generate map with rivers/roads, open player view, verify connections render

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)