### PR TITLE
chore: gitignore Claude plugin config directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 # Claude Code
 CLAUDE.md
 .claude/
+.claude-dev-helper/
+.plugin-config/
 
 # Build output
 dist/


### PR DESCRIPTION
## Summary
- Add `.claude-dev-helper/` and `.plugin-config/` to `.gitignore` — local Claude Code plugin configs that shouldn't be tracked.

## Test plan
- [x] Verify untracked dirs no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/ringo380/hexal/34?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->