### PR TITLE
♿ feat(a11y): focus trap, live announcer, and modal ARIA attributes

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
 // Sidebar - List of hexes with filtering
-import { useMemo } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useCampaign } from '../stores/CampaignContext';
 import { useSelection } from '../stores/SelectionContext';
+import { useAnnounce } from '../stores/AnnouncerContext';
 import type { Hex, ContentCategory } from '../types';
 import { hexHasUnresolvedContent, hexKey } from '../types';
 import { searchHex, getMatchHint } from '../services/search';
@@ -10,6 +11,7 @@ import Icon from './icons/Icon';
 import { onActivate } from '../utils/keyboard';
 
 function Sidebar() {
+  const announce = useAnnounce();
   const { campaign, bookmarkedHexes, regions } = useCampaign();
   const {
     selectedCoordinate,
@@ -95,6 +97,16 @@ function Sidebar() {
         return a.coordinate.q - b.coordinate.q;
       });
   }, [campaign, searchQuery, searchMatchMap, filterTerrain, filterStatus, filterHasUnresolvedHooks, filterContentTypes, filterBookmarked, bookmarkedHexes, filterRegion, hexRegionMap]);
+
+  // Announce filtered hex count to screen readers (debounced)
+  const announceTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(() => {
+    clearTimeout(announceTimerRef.current);
+    announceTimerRef.current = setTimeout(() => {
+      announce(`${filteredHexes.length} hex${filteredHexes.length === 1 ? '' : 'es'} shown`);
+    }, 300);
+    return () => clearTimeout(announceTimerRef.current);
+  }, [filteredHexes.length, announce]);
 
   const getTerrainColor = (terrain: string): string => {
     const terrainType = campaign?.terrainTypes.find(t => t.name === terrain);

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useAuth } from '../../stores/AuthContext';
 import { useSettings } from '../../stores/SettingsContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import Icon from '../icons/Icon';
 
 interface LoginModalProps {
@@ -12,6 +13,7 @@ interface LoginModalProps {
 type AuthTab = 'signin' | 'signup';
 
 function LoginModal({ onClose }: LoginModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { signIn, signUp, signInWithOAuth, loading } = useAuth();
   const { settings } = useSettings();
   const [activeTab, setActiveTab] = useState<AuthTab>('signin');
@@ -102,8 +104,6 @@ function LoginModal({ onClose }: LoginModalProps) {
       } else {
         handleSignUp();
       }
-    } else if (e.key === 'Escape') {
-      onClose();
     }
   };
 
@@ -113,15 +113,16 @@ function LoginModal({ onClose }: LoginModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="login-modal-title" onClick={onClose}>
       <div
+        ref={focusTrapRef}
         className="modal login-modal"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={handleKeyDown}
         style={{ width: 400 }}
       >
         <div className="modal-header">
-          <h3>
+          <h3 id="login-modal-title">
             <Icon name="user" size={18} /> Account
           </h3>
           <button className="modal-close" onClick={onClose} aria-label="Close">x</button>

--- a/src/components/encounters/EncounterEditorModal.tsx
+++ b/src/components/encounters/EncounterEditorModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Encounter, EncounterType, EncounterOutcome, Npc, EncounterTemplate } from '../../types/Campaign';
 import { ENCOUNTER_TYPE_INFO, OUTCOME_INFO, createEncounterTemplate } from '../../types/Campaign';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import CreatureList from './CreatureList';
 import RewardList from './RewardList';
 import NpcLinker from './NpcLinker';
@@ -17,6 +18,7 @@ const ENCOUNTER_TYPES: EncounterType[] = ['combat', 'social', 'exploration', 'pu
 const OUTCOMES: EncounterOutcome[] = ['pending', 'victory', 'defeat', 'fled', 'negotiated', 'bypassed'];
 
 function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, onClose }: EncounterEditorModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [title, setTitle] = useState(encounter.title);
   const [description, setDescription] = useState(encounter.description);
   const [difficulty, setDifficulty] = useState(encounter.difficulty ?? '');
@@ -54,10 +56,10 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-lg encounter-editor-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="encounter-editor-modal-title" onClick={onClose}>
+      <div ref={focusTrapRef} className="modal modal-lg encounter-editor-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3>Edit Encounter</h3>
+          <h3 id="encounter-editor-modal-title">Edit Encounter</h3>
           <button className="close-btn" onClick={onClose}>×</button>
         </div>
         <div className="modal-body">

--- a/src/components/modals/AlertDialog.tsx
+++ b/src/components/modals/AlertDialog.tsx
@@ -1,4 +1,5 @@
 // AlertDialog - Reusable alert modal to replace browser alert()
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface AlertDialogProps {
   title: string;
@@ -15,6 +16,8 @@ function AlertDialog({
   buttonLabel = 'OK',
   onClose
 }: AlertDialogProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+
   const variantClasses: Record<string, string> = {
     info: '',
     error: 'alert-dialog-error',
@@ -32,6 +35,7 @@ function AlertDialog({
       aria-describedby="alert-dialog-message"
     >
       <div
+        ref={focusTrapRef}
         className={`modal alert-dialog ${variantClasses[variant]}`}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/modals/ConfirmDialog.tsx
+++ b/src/components/modals/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 // ConfirmDialog - Reusable confirmation modal to replace browser confirm()
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface ConfirmDialogProps {
   title: string;
@@ -19,6 +20,8 @@ function ConfirmDialog({
   onConfirm,
   onCancel
 }: ConfirmDialogProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onCancel });
+
   return (
     <div
       className="modal-overlay"
@@ -27,7 +30,7 @@ function ConfirmDialog({
       aria-modal="true"
       aria-labelledby="confirm-dialog-title"
     >
-      <div className="modal confirm-dialog" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal confirm-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="confirm-dialog-title">{title}</h3>
         </div>

--- a/src/components/modals/CreateRegionFromSelectionModal.tsx
+++ b/src/components/modals/CreateRegionFromSelectionModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { createRegion, REGION_COLORS } from '../../types/Campaign';
 import Icon from '../icons/Icon';
 
@@ -11,6 +12,7 @@ interface CreateRegionFromSelectionModalProps {
 
 function CreateRegionFromSelectionModal({ hexKeys, onClose, onCreated }: CreateRegionFromSelectionModalProps) {
   const { regions, updateCampaignData } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   // Pick first unused color
   const usedColors = new Set(regions.map(r => r.color));
@@ -35,10 +37,10 @@ function CreateRegionFromSelectionModal({ hexKeys, onClose, onCreated }: CreateR
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="create-region-modal-title" onClick={onClose}>
+      <div className="modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="map" size={18} /> Create Region from {hexKeys.length} Hex{hexKeys.length !== 1 ? 'es' : ''}</h3>
+          <h3 id="create-region-modal-title"><Icon name="map" size={18} /> Create Region from {hexKeys.length} Hex{hexKeys.length !== 1 ? 'es' : ''}</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
         <div className="modal-body" style={{ padding: '16px 20px' }}>

--- a/src/components/modals/EncounterTableEditorModal.tsx
+++ b/src/components/modals/EncounterTableEditorModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { EncounterTable, EncounterEntry } from '../../types/Campaign';
 import Icon from '../icons/Icon';
 import { onActivate } from '../../utils/keyboard';
@@ -10,6 +11,7 @@ interface EncounterTableEditorModalProps {
 
 function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) {
   const { campaign, updateCampaignData } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const tables = campaign?.encounterTables ?? [];
   const [selectedTableId, setSelectedTableId] = useState<string | null>(tables[0]?.id ?? null);
   const [editingTable, setEditingTable] = useState<EncounterTable | null>(null);
@@ -81,10 +83,10 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal encounter-table-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="encounter-table-editor-modal-title" onClick={onClose}>
+      <div className="modal encounter-table-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3>Encounter Tables</h3>
+          <h3 id="encounter-table-editor-modal-title">Encounter Tables</h3>
           <button className="close-btn" onClick={onClose}>×</button>
         </div>
         <div className="modal-body encounter-table-layout">

--- a/src/components/modals/EncounterTemplateLibrary.tsx
+++ b/src/components/modals/EncounterTemplateLibrary.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { EncounterTemplate, EncounterType } from '../../types/Campaign';
 import { createEncounterTemplate, ENCOUNTER_TYPE_INFO } from '../../types/Campaign';
 import EncounterTypeBadge from '../encounters/EncounterTypeBadge';
@@ -16,6 +17,7 @@ const ENCOUNTER_TYPES: EncounterType[] = ['combat', 'social', 'exploration', 'pu
 
 function EncounterTemplateLibrary({ onClose }: EncounterTemplateLibraryProps) {
   const { encounterTemplates, updateCampaignData } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [searchQuery, setSearchQuery] = useState('');
   const [editingTemplate, setEditingTemplate] = useState<EncounterTemplate | null>(null);
 
@@ -48,10 +50,10 @@ function EncounterTemplateLibrary({ onClose }: EncounterTemplateLibraryProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal encounter-template-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="encounter-templates-modal-title">
+      <div className="modal encounter-template-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3>Encounter Templates</h3>
+          <h3 id="encounter-templates-modal-title">Encounter Templates</h3>
           <button className="close-btn" onClick={onClose}>×</button>
         </div>
         <div className="modal-body">

--- a/src/components/modals/ExportModal.tsx
+++ b/src/components/modals/ExportModal.tsx
@@ -1,6 +1,7 @@
 // ExportModal - Export campaign dialog
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { exportJSON, exportMarkdown } from '../../services/export';
 
 type ExportFormat = 'json' | 'markdown';
@@ -10,6 +11,7 @@ interface ExportModalProps {
 }
 
 function ExportModal({ onClose }: ExportModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { campaign } = useCampaign();
   const [format, setFormat] = useState<ExportFormat>('json');
   const [includeUndiscovered, setIncludeUndiscovered] = useState(true);
@@ -66,7 +68,7 @@ function ExportModal({ onClose }: ExportModalProps) {
       aria-modal="true"
       aria-labelledby="export-modal-title"
     >
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="export-modal-title">Export Campaign</h3>
           <button className="close-btn" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/modals/GeneratorModal.tsx
+++ b/src/components/modals/GeneratorModal.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
 import { useSelection } from '../../stores/SelectionContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useAnnounce } from '../../stores/AnnouncerContext';
 import {
   populateHex,
   generateBiomeTerrain,
@@ -23,6 +25,8 @@ interface GeneratorModalProps {
 function GeneratorModal({ onClose }: GeneratorModalProps) {
   const { campaign, getHex, updateHex, updateCampaignData } = useCampaign();
   const { selectedCoordinate } = useSelection();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+  const announce = useAnnounce();
 
   const [target, setTarget] = useState<GeneratorTarget>('selected');
   const [generateTerrainEnabled, setGenerateTerrainEnabled] = useState(true);
@@ -218,6 +222,7 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
       updateCampaignData({ hexes });
     }
 
+    announce('Content generation complete', 'assertive');
     onClose();
   };
 
@@ -231,7 +236,7 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
       aria-modal="true"
       aria-labelledby="generator-modal-title"
     >
-      <div className="modal modal-lg" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal modal-lg" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="generator-modal-title">Generate Content</h3>
           <button className="close-btn" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/modals/KeyboardShortcutsModal.tsx
+++ b/src/components/modals/KeyboardShortcutsModal.tsx
@@ -1,4 +1,5 @@
 // KeyboardShortcutsModal - Shows all keyboard shortcuts
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface KeyboardShortcutsModalProps {
   onClose: () => void;
@@ -63,6 +64,8 @@ const sections: ShortcutSection[] = [
 ];
 
 function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+
   return (
     <div
       className="modal-overlay"
@@ -72,6 +75,7 @@ function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsModalProps) {
       aria-labelledby="shortcuts-modal-title"
     >
       <div
+        ref={focusTrapRef}
         className="modal keyboard-shortcuts-modal"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/modals/LandmarkTableEditorModal.tsx
+++ b/src/components/modals/LandmarkTableEditorModal.tsx
@@ -2,6 +2,7 @@
 // Follows the same pattern as EncounterTableEditorModal
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { LandmarkTable, LandmarkEntry } from '../../types/Campaign';
 import Icon from '../icons/Icon';
 import { onActivate } from '../../utils/keyboard';
@@ -12,6 +13,7 @@ interface LandmarkTableEditorModalProps {
 
 function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
   const { campaign, updateCampaignData } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const tables = campaign?.landmarkTables ?? [];
   const [selectedTableId, setSelectedTableId] = useState<string | null>(tables[0]?.id ?? null);
   const [editingTable, setEditingTable] = useState<LandmarkTable | null>(null);
@@ -83,10 +85,10 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal encounter-table-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="landmark-table-editor-modal-title" onClick={onClose}>
+      <div className="modal encounter-table-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3>Landmark Tables</h3>
+          <h3 id="landmark-table-editor-modal-title">Landmark Tables</h3>
           <button className="close-btn" onClick={onClose}>×</button>
         </div>
         <div className="modal-body encounter-table-layout">

--- a/src/components/modals/MapExportModal.tsx
+++ b/src/components/modals/MapExportModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import Icon from '../icons/Icon';
 import { onActivate } from '../../utils/keyboard';
 import {
@@ -23,6 +24,7 @@ interface MapExportModalProps {
 
 function MapExportModal({ onClose }: MapExportModalProps) {
   const { campaign } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   // Export options state
   const [options, setOptions] = useState<MapExportOptions>({ ...DEFAULT_EXPORT_OPTIONS });
@@ -125,19 +127,17 @@ function MapExportModal({ onClose }: MapExportModalProps) {
     }
   }, [campaign, options, onClose]);
 
-  // Handle keyboard
+  // Handle Ctrl+Enter / Cmd+Enter to export
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         handleExport();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose, handleExport]);
+  }, [handleExport]);
 
   if (!campaign) return null;
 
@@ -149,7 +149,7 @@ function MapExportModal({ onClose }: MapExportModalProps) {
       aria-modal="true"
       aria-labelledby="map-export-modal-title"
     >
-      <div className="modal modal-lg map-export-modal" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal modal-lg map-export-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="map-export-modal-title">Export Map</h3>
           <button className="close-btn" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/modals/NewCampaignModal.tsx
+++ b/src/components/modals/NewCampaignModal.tsx
@@ -1,12 +1,14 @@
 // NewCampaignModal - Create new campaign dialog
 import React, { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface NewCampaignModalProps {
   onClose: () => void;
 }
 
 function NewCampaignModal({ onClose }: NewCampaignModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { newCampaign } = useCampaign();
   const [name, setName] = useState('My Campaign');
   const [width, setWidth] = useState(20);
@@ -21,8 +23,6 @@ function NewCampaignModal({ onClose }: NewCampaignModalProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       handleCreate();
-    } else if (e.key === 'Escape') {
-      onClose();
     }
   };
 
@@ -34,7 +34,7 @@ function NewCampaignModal({ onClose }: NewCampaignModalProps) {
       aria-modal="true"
       aria-labelledby="new-campaign-modal-title"
     >
-      <div className="modal" onClick={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
+      <div ref={focusTrapRef} className="modal" onClick={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
         <div className="modal-header">
           <h3 id="new-campaign-modal-title">New Campaign</h3>
           <button className="close-btn" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/modals/NpcDirectoryModal.tsx
+++ b/src/components/modals/NpcDirectoryModal.tsx
@@ -4,6 +4,7 @@ import type { Npc, NpcAttitude, Faction } from '../../types/Campaign';
 import { ATTITUDE_INFO, parseHexKey } from '../../types/Campaign';
 import { moveNpc } from '../../services/npcService';
 import { updateQuestNpcHexKey, removeFactionFromQuests } from '../../services/questService';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import AlignmentBadge from '../npcs/AlignmentBadge';
 import AttitudeBadge from '../npcs/AttitudeBadge';
 import FactionBadge from '../npcs/FactionBadge';
@@ -21,6 +22,7 @@ interface NpcDirectoryModalProps {
 type Tab = 'npcs' | 'factions';
 
 function NpcDirectoryModal({ onClose, onOpenRelationshipWeb }: NpcDirectoryModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { campaign, allNpcs, factions, updateCampaignData } = useCampaign();
   const [activeTab, setActiveTab] = useState<Tab>('npcs');
   const [searchQuery, setSearchQuery] = useState('');
@@ -127,10 +129,10 @@ function NpcDirectoryModal({ onClose, onOpenRelationshipWeb }: NpcDirectoryModal
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-xl npc-directory-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="npc-directory-modal-title" onClick={onClose}>
+      <div ref={focusTrapRef} className="modal modal-xl npc-directory-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="users" size={18} /> NPC Directory</h3>
+          <h3 id="npc-directory-modal-title"><Icon name="users" size={18} /> NPC Directory</h3>
           <div className="npc-directory-tabs">
             <button
               className={`tab-btn ${activeTab === 'npcs' ? 'active' : ''}`}

--- a/src/components/modals/QuestManagerModal.tsx
+++ b/src/components/modals/QuestManagerModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { Quest, QuestStatus, StoryArc } from '../../types/Quest';
 import { createQuest, createStoryArc, QUEST_STATUS_INFO, STORY_ARC_STATUS_INFO, STORY_ARC_COLORS } from '../../types/Quest';
 import { deleteQuestCleanup, deleteStoryArcCleanup } from '../../services/questService';
@@ -27,6 +28,7 @@ const STATUS_ORDER: Record<QuestStatus, number> = {
 
 function QuestManagerModal({ onClose }: QuestManagerModalProps) {
   const { campaign, quests, storyArcs, factions, allNpcs, updateCampaignData } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [activeTab, setActiveTab] = useState<Tab>('quests');
   const [searchQuery, setSearchQuery] = useState('');
   const [filterStatus, setFilterStatus] = useState<QuestStatus | ''>('');
@@ -145,10 +147,10 @@ function QuestManagerModal({ onClose }: QuestManagerModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal quest-manager-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="quest-manager-modal-title" onClick={onClose}>
+      <div className="modal quest-manager-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="star" size={18} /> Quests & Story Arcs</h3>
+          <h3 id="quest-manager-modal-title"><Icon name="star" size={18} /> Quests & Story Arcs</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
 

--- a/src/components/modals/RegionManagerModal.tsx
+++ b/src/components/modals/RegionManagerModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
 import { useSelection } from '../../stores/SelectionContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { Region } from '../../types/Campaign';
 import { REGION_COLORS } from '../../types/Campaign';
 import Icon from '../icons/Icon';
@@ -13,6 +14,7 @@ interface RegionManagerModalProps {
 function RegionManagerModal({ onClose }: RegionManagerModalProps) {
   const { regions, addRegion, updateRegion, deleteRegion } = useCampaign();
   const { setRegionPaintMode } = useSelection();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [selectedRegionId, setSelectedRegionId] = useState<string | null>(regions[0]?.id ?? null);
 
   const selectedRegion = regions.find(r => r.id === selectedRegionId) ?? null;
@@ -44,10 +46,10 @@ function RegionManagerModal({ onClose }: RegionManagerModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal region-manager-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="region-manager-modal-title" onClick={onClose}>
+      <div className="modal region-manager-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="map" size={18} /> Regions</h3>
+          <h3 id="region-manager-modal-title"><Icon name="map" size={18} /> Regions</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
         <div className="region-manager-body">

--- a/src/components/modals/RelationshipWebModal.tsx
+++ b/src/components/modals/RelationshipWebModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { Npc, Faction } from '../../types/Campaign';
 import { RELATIONSHIP_TYPE_INFO } from '../../types/Campaign';
 import Icon from '../icons/Icon';
@@ -17,6 +18,7 @@ interface NodePosition {
 
 function RelationshipWebModal({ onClose }: RelationshipWebModalProps) {
   const { allNpcs, factions } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [filterFactionId, setFilterFactionId] = useState<string>('');
@@ -169,10 +171,10 @@ function RelationshipWebModal({ onClose }: RelationshipWebModalProps) {
     : null;
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-xl relationship-web-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="relationship-web-modal-title">
+      <div className="modal modal-xl relationship-web-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="link" size={18} /> Relationship Web</h3>
+          <h3 id="relationship-web-modal-title"><Icon name="link" size={18} /> Relationship Web</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
         <div className="relationship-web-body">

--- a/src/components/modals/SessionLogModal.tsx
+++ b/src/components/modals/SessionLogModal.tsx
@@ -12,6 +12,7 @@ import {
   exportAllSessionsMarkdown
 } from '../../services/sessionLog';
 import { formatDate, formatTime12 } from '../../services/time';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import SessionEntryEditor from '../sessions/SessionEntryEditor';
 import { onActivate } from '../../utils/keyboard';
 import SessionTagBadge from '../sessions/SessionTagBadge';
@@ -25,6 +26,7 @@ interface SessionLogModalProps {
 type Tab = 'sessions' | 'timeline' | 'export';
 
 function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { campaign, updateCampaignData, sessions, sessionLog, timeWeather } = useCampaign();
   const [activeTab, setActiveTab] = useState<Tab>('sessions');
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
@@ -184,10 +186,10 @@ function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-xl session-log-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="session-log-modal-title" onClick={onClose}>
+      <div ref={focusTrapRef} className="modal modal-xl session-log-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="calendar" size={18} /> Session Log</h3>
+          <h3 id="session-log-modal-title"><Icon name="calendar" size={18} /> Session Log</h3>
           <div className="session-log-tabs">
             <button
               className={`tab-btn ${activeTab === 'sessions' ? 'active' : ''}`}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useSettings } from '../../stores/SettingsContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { AISettings, CloudSettings, GeneralSettings } from '../../stores/SettingsContext';
 
 interface SettingsModalProps {
@@ -12,6 +13,7 @@ type SettingsTab = 'general' | 'ai' | 'cloud';
 
 function SettingsModal({ onClose }: SettingsModalProps) {
   const { settings, updateSettings } = useSettings();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [activeTab, setActiveTab] = useState<SettingsTab>('general');
 
   // Local state for editing (commit on blur/save)
@@ -41,14 +43,15 @@ function SettingsModal({ onClose }: SettingsModalProps) {
   ];
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="settings-modal-title">
       <div
         className="modal settings-modal"
+        ref={focusTrapRef}
         onClick={(e) => e.stopPropagation()}
         style={{ width: 520, maxHeight: '80vh' }}
       >
         <div className="modal-header">
-          <h3>Settings</h3>
+          <h3 id="settings-modal-title">Settings</h3>
           <button className="modal-close" onClick={onClose} aria-label="Close">×</button>
         </div>
 

--- a/src/components/modals/ShareCampaignModal.tsx
+++ b/src/components/modals/ShareCampaignModal.tsx
@@ -1,6 +1,7 @@
 // ShareCampaignModal — Campaign sharing and invite link management (placeholder)
 
 import { useState } from 'react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import Icon from '../icons/Icon';
 
 interface ShareCampaignModalProps {
@@ -12,17 +13,19 @@ interface ShareCampaignModalProps {
 type InviteRole = 'dm' | 'player' | 'viewer';
 
 function ShareCampaignModal({ campaignId: _campaignId, campaignName, onClose }: ShareCampaignModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [inviteRole, setInviteRole] = useState<InviteRole>('player');
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="share-campaign-modal-title">
       <div
         className="modal share-campaign-modal"
+        ref={focusTrapRef}
         onClick={(e) => e.stopPropagation()}
         style={{ width: 480 }}
       >
         <div className="modal-header">
-          <h3>
+          <h3 id="share-campaign-modal-title">
             <Icon name="users" size={18} /> Share "{campaignName}"
           </h3>
           <button className="modal-close" onClick={onClose} aria-label="Close">x</button>

--- a/src/components/modals/TerrainEditorModal.tsx
+++ b/src/components/modals/TerrainEditorModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { TerrainType } from '../../types/Campaign';
 import { REGION_COLORS } from '../../types/Campaign';
 import Icon from '../icons/Icon';
@@ -31,6 +32,7 @@ function TerrainEditorModal({ onClose }: TerrainEditorModalProps) {
     deleteTerrainType,
     renameTerrainType
   } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [selectedId, setSelectedId] = useState<string | null>(terrainTypes[0]?.id ?? null);
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [replacementId, setReplacementId] = useState<string>('');
@@ -73,10 +75,10 @@ function TerrainEditorModal({ onClose }: TerrainEditorModalProps) {
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal terrain-editor-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="terrain-editor-modal-title">
+      <div className="modal terrain-editor-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3><Icon name="hexagon" size={18} /> Terrain Types</h3>
+          <h3 id="terrain-editor-modal-title"><Icon name="hexagon" size={18} /> Terrain Types</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
         <div className="terrain-editor-body">

--- a/src/components/modals/TimeControlsModal.tsx
+++ b/src/components/modals/TimeControlsModal.tsx
@@ -1,6 +1,7 @@
 // TimeControlsModal - Modal for time/calendar controls
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { CALENDAR_PRESETS, getTotalDaysInYear } from '../../data/calendars';
 import { getTimeOfDayLabel, getTimeOfDayIcon } from '../../services/time';
 import { CalendarPreset, SEASON_ICONS } from '../../types/Weather';
@@ -22,6 +23,7 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
     advanceTimeBy,
     initTimeWeather
   } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   // Custom advance inputs
   const [customHours, setCustomHours] = useState<number>(1);
@@ -37,7 +39,7 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
         aria-modal="true"
         aria-labelledby="time-setup-modal-title"
       >
-        <div className="modal time-controls-modal" onClick={(e) => e.stopPropagation()}>
+        <div ref={focusTrapRef} className="modal time-controls-modal" onClick={(e) => e.stopPropagation()}>
           <div className="modal-header">
             <h2 id="time-setup-modal-title">Time & Weather Setup</h2>
             <button className="btn btn-icon" onClick={onClose} aria-label="Close">×</button>
@@ -119,7 +121,7 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
       aria-modal="true"
       aria-labelledby="time-controls-modal-title"
     >
-      <div className="modal time-controls-modal" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal time-controls-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 id="time-controls-modal-title">Time Controls</h2>
           <button className="btn btn-icon" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/modals/UnsavedChangesDialog.tsx
+++ b/src/components/modals/UnsavedChangesDialog.tsx
@@ -1,4 +1,5 @@
 // UnsavedChangesDialog - Shown when user tries to close/switch with unsaved changes
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface UnsavedChangesDialogProps {
   onSave: () => void;
@@ -13,6 +14,8 @@ function UnsavedChangesDialog({
   onOpenNewWindow,
   onCancel
 }: UnsavedChangesDialogProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onCancel });
+
   return (
     <div
       className="modal-overlay"
@@ -22,7 +25,7 @@ function UnsavedChangesDialog({
       aria-labelledby="unsaved-changes-title"
       aria-describedby="unsaved-changes-description"
     >
-      <div className="modal unsaved-dialog" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal unsaved-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="unsaved-changes-title">Unsaved Changes</h3>
         </div>

--- a/src/components/modals/WeatherSettingsModal.tsx
+++ b/src/components/modals/WeatherSettingsModal.tsx
@@ -1,6 +1,7 @@
 // WeatherSettingsModal - Modal for weather configuration
 import { useState } from 'react';
 import { useCampaign } from '../../stores/CampaignContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { getWeatherSummary, describeWeather } from '../../services/weather';
 import Icon from '../icons/Icon';
 import { getWeatherEffects } from '../../data/weatherEffects';
@@ -49,6 +50,7 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
     updateWeatherSettings,
     initTimeWeather
   } = useCampaign();
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   // Local state for weather editing
   const [editingWeather, setEditingWeather] = useState<Weather | null>(null);
@@ -63,7 +65,7 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
         aria-modal="true"
         aria-labelledby="weather-setup-modal-title"
       >
-        <div className="modal weather-settings-modal" onClick={(e) => e.stopPropagation()}>
+        <div ref={focusTrapRef} className="modal weather-settings-modal" onClick={(e) => e.stopPropagation()}>
           <div className="modal-header">
             <h2 id="weather-setup-modal-title">Weather Settings</h2>
             <button className="btn btn-icon" onClick={onClose} aria-label="Close">×</button>
@@ -134,7 +136,7 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
       aria-modal="true"
       aria-labelledby="weather-settings-modal-title"
     >
-      <div className="modal weather-settings-modal" onClick={(e) => e.stopPropagation()}>
+      <div ref={focusTrapRef} className="modal weather-settings-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 id="weather-settings-modal-title">Weather Settings</h2>
           <button className="btn btn-icon" onClick={onClose} aria-label="Close">×</button>

--- a/src/components/npcs/NpcEditorModal.tsx
+++ b/src/components/npcs/NpcEditorModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { Npc, NpcAlignment, NpcAttitude, Faction } from '../../types/Campaign';
 import { ALIGNMENT_LABELS, ATTITUDE_INFO } from '../../types/Campaign';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import RelationshipEditor from './RelationshipEditor';
 
 const ALIGNMENTS: NpcAlignment[] = [
@@ -21,6 +22,7 @@ interface NpcEditorModalProps {
 }
 
 function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const [title, setTitle] = useState(npc.title);
   const [race, setRace] = useState(npc.race ?? '');
   const [npcClass, setNpcClass] = useState(npc.class ?? '');
@@ -57,10 +59,10 @@ function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorMo
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-lg npc-editor-modal" onClick={(e) => e.stopPropagation()}>
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="npc-editor-modal-title" onClick={onClose}>
+      <div ref={focusTrapRef} className="modal modal-lg npc-editor-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h3>Edit NPC</h3>
+          <h3 id="npc-editor-modal-title">Edit NPC</h3>
           <button className="close-btn" onClick={onClose}>&times;</button>
         </div>
         <div className="modal-body">

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,82 @@
+// useFocusTrap — Traps keyboard focus within a container (for modals/dialogs).
+// Stores previous focus on mount, restores on unmount. Traps Tab/Shift+Tab.
+
+import { useRef, useEffect, useCallback } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+interface UseFocusTrapOptions {
+  onEscape?: () => void;
+}
+
+export function useFocusTrap<T extends HTMLElement = HTMLDivElement>(
+  options: UseFocusTrapOptions = {}
+) {
+  const containerRef = useRef<T>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        options.onEscape?.();
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    },
+    [options]
+  );
+
+  useEffect(() => {
+    previousFocusRef.current = document.activeElement;
+
+    const container = containerRef.current;
+    if (container) {
+      const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, [handleKeyDown]);
+
+  return containerRef;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import type { ViewMode } from './stores/ViewModeContext';
 import PlayerApp from './components/player/PlayerApp';
 import { SettingsProvider } from './stores/SettingsContext';
 import { AuthProvider } from './stores/AuthContext';
+import { AnnouncerProvider } from './stores/AnnouncerContext';
 import { createPersistenceAdapter } from './services/persistence';
 import './styles/app.css';
 import './styles/auth.css';
@@ -27,7 +28,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <AuthProvider>
             <CampaignProvider adapter={persistenceAdapter}>
               <SelectionProvider>
-                <App />
+                <AnnouncerProvider>
+                  <App />
+                </AnnouncerProvider>
               </SelectionProvider>
             </CampaignProvider>
           </AuthProvider>

--- a/src/stores/AnnouncerContext.tsx
+++ b/src/stores/AnnouncerContext.tsx
@@ -1,0 +1,36 @@
+// AnnouncerContext — Provides screen-reader announcements via aria-live regions.
+// Usage: const announce = useAnnounce(); announce('5 hexes found');
+
+import { createContext, useContext, useCallback, useRef, type ReactNode } from 'react';
+
+type Priority = 'polite' | 'assertive';
+type AnnounceFn = (message: string, priority?: Priority) => void;
+
+const AnnouncerContext = createContext<AnnounceFn>(() => {});
+
+export function useAnnounce(): AnnounceFn {
+  return useContext(AnnouncerContext);
+}
+
+export function AnnouncerProvider({ children }: { children: ReactNode }) {
+  const politeRef = useRef<HTMLDivElement>(null);
+  const assertiveRef = useRef<HTMLDivElement>(null);
+
+  const announce: AnnounceFn = useCallback((message, priority = 'polite') => {
+    const el = priority === 'assertive' ? assertiveRef.current : politeRef.current;
+    if (!el) return;
+    // Clear-then-set to force re-announcement of repeated messages
+    el.textContent = '';
+    setTimeout(() => {
+      el.textContent = message;
+    }, 50);
+  }, []);
+
+  return (
+    <AnnouncerContext.Provider value={announce}>
+      {children}
+      <div ref={politeRef} aria-live="polite" className="sr-only" role="status" />
+      <div ref={assertiveRef} aria-live="assertive" className="sr-only" role="alert" />
+    </AnnouncerContext.Provider>
+  );
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -175,6 +175,19 @@ select:focus {
   outline-offset: -2px;
 }
 
+/* Screen-reader only — visually hidden but accessible */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 textarea {
   resize: vertical;
   min-height: 60px;


### PR DESCRIPTION
## Summary

Closes #27, #30

- **`useFocusTrap` hook** — Traps Tab/Shift+Tab within modals, handles Escape, stores/restores focus on mount/unmount
- **`AnnouncerContext`** — Provides `useAnnounce()` hook for screen-reader announcements via `aria-live` regions (polite + assertive)
- **`.sr-only` CSS class** — Visually hidden, screen-reader accessible
- Applied `useFocusTrap` to all **25 modals** — removes redundant manual Escape handlers
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to **15 modals** that were missing them
- Sidebar announces filtered hex count (debounced 300ms)
- GeneratorModal announces generation complete

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 299 tests pass
- [ ] Manual: Tab cycles within each modal, doesn't escape to background
- [ ] Manual: Shift+Tab cycles backwards
- [ ] Manual: Escape closes modal, focus returns to trigger
- [ ] VoiceOver: modal titles announced on open

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/ringo380/hexal/35?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->