### PR TITLE
♿ feat(a11y): form label associations and icon-only button labels

### DIFF
--- a/src/components/HexDetail.tsx
+++ b/src/components/HexDetail.tsx
@@ -706,7 +706,7 @@ function ContentItemEditor({ item, category, onSave, onClose }: ContentItemEdito
       <div className="modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3>Edit {categoryConfig[category].title.slice(0, -1)}</h3>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="modal-body">
           <div className="field-group">
@@ -1100,6 +1100,7 @@ function HexQuestSection({ quests, onOpenQuestManager }: HexQuestSectionProps) {
                     className="btn-icon-small"
                     onClick={(e) => { e.stopPropagation(); onOpenQuestManager(); }}
                     title="View in Quest Manager"
+                    aria-label="View in Quest Manager"
                   >
                     <Icon name="export" size={12} />
                   </button>

--- a/src/components/HexGrid.tsx
+++ b/src/components/HexGrid.tsx
@@ -1373,7 +1373,7 @@ function HexGrid({ onCreateRegionFromSelection }: HexGridProps) {
       )}
       {/* Zoom controls - fixed position */}
       <div className="zoom-controls">
-        <button className="zoom-btn" onClick={zoomOut} title="Zoom out (Cmd/Ctrl -)">−</button>
+        <button className="zoom-btn" onClick={zoomOut} title="Zoom out (Cmd/Ctrl -)" aria-label="Zoom out">−</button>
         <input
           type="range"
           className="zoom-slider"
@@ -1384,9 +1384,9 @@ function HexGrid({ onCreateRegionFromSelection }: HexGridProps) {
           onChange={handleZoomSliderChange}
           title={`Zoom: ${Math.round(zoomLevel * 100)}%`}
         />
-        <button className="zoom-btn" onClick={zoomIn} title="Zoom in (Cmd/Ctrl +)">+</button>
+        <button className="zoom-btn" onClick={zoomIn} title="Zoom in (Cmd/Ctrl +)" aria-label="Zoom in">+</button>
         <span className="zoom-label">{Math.round(zoomLevel * 100)}%</span>
-        <button className="zoom-btn zoom-reset" onClick={resetZoom} title="Reset zoom (Cmd/Ctrl 0)">⟲</button>
+        <button className="zoom-btn zoom-reset" onClick={resetZoom} title="Reset zoom (Cmd/Ctrl 0)" aria-label="Reset zoom">⟲</button>
       </div>
       {/* Content indicator tooltip */}
       {tooltip && (

--- a/src/components/MainEditor.tsx
+++ b/src/components/MainEditor.tsx
@@ -238,6 +238,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
             placeholder="Search... (⌘F)"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
+            aria-label="Search hexes"
           />
 
           <div className="filter-dropdown">
@@ -260,6 +261,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
                   <select
                     value={filterTerrain ?? ''}
                     onChange={(e) => setFilterTerrain(e.target.value || null)}
+                    aria-label="Filter by terrain"
                   >
                     <option value="">All Terrains</option>
                     {campaign.terrainTypes.map((t) => (
@@ -272,6 +274,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
                   <select
                     value={filterStatus ?? ''}
                     onChange={(e) => setFilterStatus((e.target.value || null) as any)}
+                    aria-label="Filter by status"
                   >
                     <option value="">All Statuses</option>
                     <option value="undiscovered">Undiscovered</option>
@@ -285,6 +288,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport }: MainEditorProps) 
                     <select
                       value={filterRegion ?? ''}
                       onChange={(e) => setFilterRegion(e.target.value || null)}
+                      aria-label="Filter by region"
                     >
                       <option value="">All Regions</option>
                       {regions.map((r) => (

--- a/src/components/encounters/CreatureList.tsx
+++ b/src/components/encounters/CreatureList.tsx
@@ -31,6 +31,7 @@ function CreatureList({ creatures, onChange }: CreatureListProps) {
             value={creature.name}
             onChange={(e) => updateCreature(creature.id, { name: e.target.value })}
             placeholder="Creature name"
+            aria-label="Creature name"
           />
           <input
             type="number"
@@ -38,6 +39,7 @@ function CreatureList({ creatures, onChange }: CreatureListProps) {
             value={creature.count}
             onChange={(e) => updateCreature(creature.id, { count: Math.max(1, parseInt(e.target.value) || 1) })}
             min={1}
+            aria-label="Creature count"
           />
           <input
             type="text"
@@ -45,6 +47,7 @@ function CreatureList({ creatures, onChange }: CreatureListProps) {
             value={creature.cr || ''}
             onChange={(e) => updateCreature(creature.id, { cr: e.target.value || undefined })}
             placeholder="CR"
+            aria-label="Creature CR"
           />
           <input
             type="text"
@@ -52,11 +55,13 @@ function CreatureList({ creatures, onChange }: CreatureListProps) {
             value={creature.notes || ''}
             onChange={(e) => updateCreature(creature.id, { notes: e.target.value || undefined })}
             placeholder="Notes"
+            aria-label="Creature notes"
           />
           <button
             className="btn-icon-small danger"
             onClick={() => removeCreature(creature.id)}
             title="Remove creature"
+            aria-label="Remove creature"
           >
             <Icon name="close" size={14} />
           </button>

--- a/src/components/encounters/EncounterEditorModal.tsx
+++ b/src/components/encounters/EncounterEditorModal.tsx
@@ -60,13 +60,14 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
       <div ref={focusTrapRef} className="modal modal-lg encounter-editor-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="encounter-editor-modal-title">Edit Encounter</h3>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="modal-body">
           {/* Basic Info */}
           <div className="field-group">
-            <label>Title</label>
+            <label htmlFor="enc-editor-title">Title</label>
             <input
+              id="enc-editor-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -76,16 +77,17 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
 
           <div className="field-row">
             <div className="field-group">
-              <label>Encounter Type</label>
-              <select value={encounterType} onChange={(e) => setEncounterType(e.target.value as EncounterType)}>
+              <label htmlFor="enc-editor-type">Encounter Type</label>
+              <select id="enc-editor-type" value={encounterType} onChange={(e) => setEncounterType(e.target.value as EncounterType)}>
                 {ENCOUNTER_TYPES.map(t => (
                   <option key={t} value={t}>{ENCOUNTER_TYPE_INFO[t].label}</option>
                 ))}
               </select>
             </div>
             <div className="field-group">
-              <label>Difficulty / CR</label>
+              <label htmlFor="enc-editor-difficulty">Difficulty / CR</label>
               <input
+                id="enc-editor-difficulty"
                 type="text"
                 value={difficulty}
                 onChange={(e) => setDifficulty(e.target.value)}
@@ -95,8 +97,9 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
           </div>
 
           <div className="field-group">
-            <label>Description</label>
+            <label htmlFor="enc-editor-description">Description</label>
             <textarea
+              id="enc-editor-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
@@ -115,8 +118,8 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
           {/* Outcome */}
           <div className="field-row">
             <div className="field-group">
-              <label>Outcome</label>
-              <select value={outcome} onChange={(e) => setOutcome(e.target.value as EncounterOutcome)}>
+              <label htmlFor="enc-editor-outcome">Outcome</label>
+              <select id="enc-editor-outcome" value={outcome} onChange={(e) => setOutcome(e.target.value as EncounterOutcome)}>
                 {OUTCOMES.map(o => (
                   <option key={o} value={o}>{OUTCOME_INFO[o].label}</option>
                 ))}
@@ -126,8 +129,9 @@ function EncounterEditorModal({ encounter, allNpcs, onSave, onSaveAsTemplate, on
 
           {outcome !== 'pending' && (
             <div className="field-group">
-              <label>Outcome Notes</label>
+              <label htmlFor="enc-editor-outcome-notes">Outcome Notes</label>
               <textarea
+                id="enc-editor-outcome-notes"
                 value={outcomeNotes}
                 onChange={(e) => setOutcomeNotes(e.target.value)}
                 rows={2}

--- a/src/components/encounters/NpcLinker.tsx
+++ b/src/components/encounters/NpcLinker.tsx
@@ -50,6 +50,7 @@ function NpcLinker({ linkedNpcs, allNpcs, onChange }: NpcLinkerProps) {
             className="btn-icon-small danger"
             onClick={() => removeLink(ref.npcId)}
             title="Unlink NPC"
+            aria-label="Unlink NPC"
           >
             <Icon name="close" size={14} />
           </button>
@@ -62,6 +63,7 @@ function NpcLinker({ linkedNpcs, allNpcs, onChange }: NpcLinkerProps) {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search NPCs..."
+            aria-label="Search NPCs to link"
             autoFocus
           />
           <div className="npc-picker-results">

--- a/src/components/encounters/RewardList.tsx
+++ b/src/components/encounters/RewardList.tsx
@@ -31,6 +31,7 @@ function RewardList({ rewards, onChange }: RewardListProps) {
             className="reward-type"
             value={reward.type}
             onChange={(e) => updateReward(reward.id, { type: e.target.value as EncounterReward['type'] })}
+            aria-label="Reward type"
           >
             {REWARD_TYPES.map(t => (
               <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
@@ -42,6 +43,7 @@ function RewardList({ rewards, onChange }: RewardListProps) {
             value={reward.description}
             onChange={(e) => updateReward(reward.id, { description: e.target.value })}
             placeholder="Description"
+            aria-label="Reward description"
           />
           <input
             type="number"
@@ -49,11 +51,13 @@ function RewardList({ rewards, onChange }: RewardListProps) {
             value={reward.quantity ?? ''}
             onChange={(e) => updateReward(reward.id, { quantity: e.target.value ? parseInt(e.target.value) : undefined })}
             placeholder="Qty"
+            aria-label="Reward quantity"
           />
           <button
             className="btn-icon-small danger"
             onClick={() => removeReward(reward.id)}
             title="Remove reward"
+            aria-label="Remove reward"
           >
             <Icon name="close" size={14} />
           </button>

--- a/src/components/modals/CreateRegionFromSelectionModal.tsx
+++ b/src/components/modals/CreateRegionFromSelectionModal.tsx
@@ -41,7 +41,7 @@ function CreateRegionFromSelectionModal({ hexKeys, onClose, onCreated }: CreateR
       <div className="modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="create-region-modal-title"><Icon name="map" size={18} /> Create Region from {hexKeys.length} Hex{hexKeys.length !== 1 ? 'es' : ''}</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="modal-body" style={{ padding: '16px 20px' }}>
           <div style={{ marginBottom: 12 }}>

--- a/src/components/modals/EncounterTableEditorModal.tsx
+++ b/src/components/modals/EncounterTableEditorModal.tsx
@@ -87,7 +87,7 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
       <div className="modal encounter-table-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="encounter-table-editor-modal-title">Encounter Tables</h3>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="modal-body encounter-table-layout">
           {/* Left panel - table list */}
@@ -108,6 +108,7 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
                   className="btn-icon-small danger"
                   onClick={(e) => { e.stopPropagation(); deleteTable(table.id); }}
                   title="Delete table"
+                  aria-label="Delete table"
                 >
                   <Icon name="trash" size={12} />
                 </button>
@@ -123,16 +124,18 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
                 {editingTable ? (
                   <div className="encounter-table-edit-header">
                     <div className="field-group">
-                      <label>Table Name</label>
+                      <label htmlFor="enc-table-name">Table Name</label>
                       <input
+                        id="enc-table-name"
                         type="text"
                         value={editingTable.name}
                         onChange={(e) => setEditingTable({ ...editingTable, name: e.target.value })}
                       />
                     </div>
                     <div className="field-group">
-                      <label>Terrain</label>
+                      <label htmlFor="enc-table-terrain">Terrain</label>
                       <select
+                        id="enc-table-terrain"
                         value={editingTable.terrain}
                         onChange={(e) => setEditingTable({ ...editingTable, terrain: e.target.value })}
                       >
@@ -170,6 +173,7 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
                         value={entry.title}
                         onChange={(e) => updateEntry(entry.id, { title: e.target.value })}
                         placeholder="Title"
+                        aria-label="Entry name"
                       />
                       <input
                         type="text"
@@ -177,6 +181,7 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
                         value={entry.difficulty}
                         onChange={(e) => updateEntry(entry.id, { difficulty: e.target.value })}
                         placeholder="Difficulty"
+                        aria-label="Entry difficulty"
                       />
                       <input
                         type="number"
@@ -184,12 +189,13 @@ function EncounterTableEditorModal({ onClose }: EncounterTableEditorModalProps) 
                         value={entry.weight}
                         onChange={(e) => updateEntry(entry.id, { weight: Math.max(1, parseInt(e.target.value) || 1) })}
                         min={1}
-                        title="Weight"
+                        aria-label="Entry weight"
                       />
                       <button
                         className="btn-icon-small danger"
                         onClick={() => deleteEntry(entry.id)}
                         title="Delete entry"
+                        aria-label="Delete entry"
                       >
                         <Icon name="close" size={14} />
                       </button>

--- a/src/components/modals/EncounterTemplateLibrary.tsx
+++ b/src/components/modals/EncounterTemplateLibrary.tsx
@@ -54,7 +54,7 @@ function EncounterTemplateLibrary({ onClose }: EncounterTemplateLibraryProps) {
       <div className="modal encounter-template-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="encounter-templates-modal-title">Encounter Templates</h3>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="modal-body">
           <div className="template-toolbar">
@@ -64,6 +64,7 @@ function EncounterTemplateLibrary({ onClose }: EncounterTemplateLibraryProps) {
               placeholder="Search templates..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search encounter templates"
             />
             <button className="btn btn-primary btn-small" onClick={addTemplate}>
               + New Template
@@ -164,41 +165,41 @@ function TemplateEditor({ template, onSave, onCancel }: TemplateEditorProps) {
   return (
     <div className="template-editor">
       <div className="field-group">
-        <label>Template Name</label>
-        <input type="text" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
+        <label htmlFor="tmpl-name">Template Name</label>
+        <input id="tmpl-name" type="text" value={name} onChange={(e) => setName(e.target.value)} autoFocus />
       </div>
 
       <div className="field-row">
         <div className="field-group">
-          <label>Encounter Type</label>
-          <select value={encounterType} onChange={(e) => setEncounterType(e.target.value as EncounterType)}>
+          <label htmlFor="tmpl-type">Encounter Type</label>
+          <select id="tmpl-type" value={encounterType} onChange={(e) => setEncounterType(e.target.value as EncounterType)}>
             {ENCOUNTER_TYPES.map(t => (
               <option key={t} value={t}>{ENCOUNTER_TYPE_INFO[t].label}</option>
             ))}
           </select>
         </div>
         <div className="field-group">
-          <label>Difficulty</label>
-          <input type="text" value={difficulty} onChange={(e) => setDifficulty(e.target.value)} placeholder="e.g., CR 2, Hard" />
+          <label htmlFor="tmpl-difficulty">Difficulty</label>
+          <input id="tmpl-difficulty" type="text" value={difficulty} onChange={(e) => setDifficulty(e.target.value)} placeholder="e.g., CR 2, Hard" />
         </div>
       </div>
 
       <div className="field-group">
-        <label>Description</label>
-        <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={3} />
+        <label htmlFor="tmpl-description">Description</label>
+        <textarea id="tmpl-description" value={description} onChange={(e) => setDescription(e.target.value)} rows={3} />
       </div>
 
       <CreatureList creatures={creatures} onChange={setCreatures} />
       <RewardList rewards={rewards} onChange={setRewards} />
 
       <div className="field-group">
-        <label>Tags (comma-separated)</label>
-        <input type="text" value={tags} onChange={(e) => setTags(e.target.value)} placeholder="e.g., undead, forest, night" />
+        <label htmlFor="tmpl-tags">Tags (comma-separated)</label>
+        <input id="tmpl-tags" type="text" value={tags} onChange={(e) => setTags(e.target.value)} placeholder="e.g., undead, forest, night" />
       </div>
 
       <div className="field-group">
-        <label>Terrain Affinity (comma-separated)</label>
-        <input type="text" value={terrainAffinity} onChange={(e) => setTerrainAffinity(e.target.value)} placeholder="e.g., Forest, Swamp" />
+        <label htmlFor="tmpl-terrain">Terrain Affinity (comma-separated)</label>
+        <input id="tmpl-terrain" type="text" value={terrainAffinity} onChange={(e) => setTerrainAffinity(e.target.value)} placeholder="e.g., Forest, Swamp" />
       </div>
 
       <div className="template-editor-actions">

--- a/src/components/modals/GeneratorModal.tsx
+++ b/src/components/modals/GeneratorModal.tsx
@@ -244,8 +244,8 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
         <div className="modal-body">
           {/* Target selection */}
           <div className="field-group">
-            <label>Target</label>
-            <select value={target} onChange={(e) => setTarget(e.target.value as GeneratorTarget)}>
+            <label htmlFor="gen-target">Target</label>
+            <select id="gen-target" value={target} onChange={(e) => setTarget(e.target.value as GeneratorTarget)}>
               <option value="selected">Selected Hex</option>
               <option value="allEmpty">All Empty Hexes</option>
             </select>
@@ -256,9 +256,10 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
 
           {/* Seed input */}
           <div className="field-group">
-            <label>Seed</label>
+            <label htmlFor="gen-seed">Seed</label>
             <div style={{ display: 'flex', gap: '8px' }}>
               <input
+                id="gen-seed"
                 type="text"
                 value={seed}
                 onChange={(e) => setSeed(e.target.value)}
@@ -287,10 +288,11 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
           {generateTerrainEnabled && target === 'allEmpty' && (
             <>
               <div className="field-group" style={{ paddingLeft: '20px' }}>
-                <label>
+                <label htmlFor="gen-clustering">
                   Clustering Strength: {Math.round(clusterStrength * 100)}%
                 </label>
                 <input
+                  id="gen-clustering"
                   type="range"
                   min={0}
                   max={1}
@@ -302,10 +304,11 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
               </div>
 
               <div className="field-group" style={{ paddingLeft: '20px' }}>
-                <label>
+                <label htmlFor="gen-variety">
                   Terrain Variety: {Math.round(terrainVariety * 100)}%
                 </label>
                 <input
+                  id="gen-variety"
                   type="range"
                   min={0}
                   max={1}
@@ -331,10 +334,11 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
 
           {generateEncounterEnabled && (
             <div className="field-group" style={{ paddingLeft: '20px' }}>
-              <label>
+              <label htmlFor="gen-encounter-density">
                 Encounter Density: {Math.round(encounterDensity * 100)}%
               </label>
               <input
+                id="gen-encounter-density"
                 type="range"
                 min={0}
                 max={1}
@@ -358,10 +362,11 @@ function GeneratorModal({ onClose }: GeneratorModalProps) {
 
           {generateLandmarkEnabled && (
             <div className="field-group" style={{ paddingLeft: '20px' }}>
-              <label>
+              <label htmlFor="gen-landmark-density">
                 Landmark Density: {Math.round(landmarkDensity * 100)}%
               </label>
               <input
+                id="gen-landmark-density"
                 type="range"
                 min={0}
                 max={1}

--- a/src/components/modals/LandmarkTableEditorModal.tsx
+++ b/src/components/modals/LandmarkTableEditorModal.tsx
@@ -89,7 +89,7 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
       <div className="modal encounter-table-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="landmark-table-editor-modal-title">Landmark Tables</h3>
-          <button className="close-btn" onClick={onClose}>×</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">×</button>
         </div>
         <div className="modal-body encounter-table-layout">
           {/* Left panel - table list */}
@@ -110,6 +110,7 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
                   className="btn-icon-small danger"
                   onClick={(e) => { e.stopPropagation(); deleteTable(table.id); }}
                   title="Delete table"
+                  aria-label="Delete table"
                 >
                   <Icon name="trash" size={12} />
                 </button>
@@ -125,16 +126,18 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
                 {editingTable ? (
                   <div className="encounter-table-edit-header">
                     <div className="field-group">
-                      <label>Table Name</label>
+                      <label htmlFor="landmark-table-name">Table Name</label>
                       <input
+                        id="landmark-table-name"
                         type="text"
                         value={editingTable.name}
                         onChange={(e) => setEditingTable({ ...editingTable, name: e.target.value })}
                       />
                     </div>
                     <div className="field-group">
-                      <label>Terrain</label>
+                      <label htmlFor="landmark-table-terrain">Terrain</label>
                       <select
+                        id="landmark-table-terrain"
                         value={editingTable.terrain}
                         onChange={(e) => setEditingTable({ ...editingTable, terrain: e.target.value })}
                       >
@@ -172,6 +175,7 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
                         value={entry.title}
                         onChange={(e) => updateEntry(entry.id, { title: e.target.value })}
                         placeholder="Title"
+                        aria-label="Entry name"
                       />
                       <input
                         type="text"
@@ -179,6 +183,7 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
                         value={entry.rarity}
                         onChange={(e) => updateEntry(entry.id, { rarity: e.target.value })}
                         placeholder="Rarity"
+                        aria-label="Entry rarity"
                       />
                       <input
                         type="number"
@@ -186,12 +191,13 @@ function LandmarkTableEditorModal({ onClose }: LandmarkTableEditorModalProps) {
                         value={entry.weight}
                         onChange={(e) => updateEntry(entry.id, { weight: Math.max(1, parseInt(e.target.value) || 1) })}
                         min={1}
-                        title="Weight"
+                        aria-label="Entry weight"
                       />
                       <button
                         className="btn-icon-small danger"
                         onClick={() => deleteEntry(entry.id)}
                         title="Delete entry"
+                        aria-label="Delete entry"
                       >
                         <Icon name="close" size={14} />
                       </button>

--- a/src/components/modals/NewCampaignModal.tsx
+++ b/src/components/modals/NewCampaignModal.tsx
@@ -41,8 +41,9 @@ function NewCampaignModal({ onClose }: NewCampaignModalProps) {
         </div>
         <div className="modal-body">
           <div className="field-group">
-            <label>Campaign Name</label>
+            <label htmlFor="new-campaign-name">Campaign Name</label>
             <input
+              id="new-campaign-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
@@ -51,19 +52,19 @@ function NewCampaignModal({ onClose }: NewCampaignModalProps) {
           </div>
           <div className="field-row">
             <div className="field-group">
-              <label>Width</label>
-              <div className="stepper">
-                <button onClick={() => setWidth(Math.max(5, width - 1))}>−</button>
+              <label id="new-campaign-width">Width</label>
+              <div className="stepper" role="group" aria-labelledby="new-campaign-width">
+                <button aria-label="Decrease width" onClick={() => setWidth(Math.max(5, width - 1))}>−</button>
                 <span>{width}</span>
-                <button onClick={() => setWidth(Math.min(50, width + 1))}>+</button>
+                <button aria-label="Increase width" onClick={() => setWidth(Math.min(50, width + 1))}>+</button>
               </div>
             </div>
             <div className="field-group">
-              <label>Height</label>
-              <div className="stepper">
-                <button onClick={() => setHeight(Math.max(5, height - 1))}>−</button>
+              <label id="new-campaign-height">Height</label>
+              <div className="stepper" role="group" aria-labelledby="new-campaign-height">
+                <button aria-label="Decrease height" onClick={() => setHeight(Math.max(5, height - 1))}>−</button>
                 <span>{height}</span>
-                <button onClick={() => setHeight(Math.min(50, height + 1))}>+</button>
+                <button aria-label="Increase height" onClick={() => setHeight(Math.min(50, height + 1))}>+</button>
               </div>
             </div>
           </div>

--- a/src/components/modals/NpcDirectoryModal.tsx
+++ b/src/components/modals/NpcDirectoryModal.tsx
@@ -147,7 +147,7 @@ function NpcDirectoryModal({ onClose, onOpenRelationshipWeb }: NpcDirectoryModal
               Factions ({factions.length})
             </button>
           </div>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
 
         {activeTab === 'npcs' ? (

--- a/src/components/modals/QuestManagerModal.tsx
+++ b/src/components/modals/QuestManagerModal.tsx
@@ -151,7 +151,7 @@ function QuestManagerModal({ onClose }: QuestManagerModalProps) {
       <div className="modal quest-manager-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="quest-manager-modal-title"><Icon name="star" size={18} /> Quests & Story Arcs</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
 
         {/* Tabs */}

--- a/src/components/modals/RegionManagerModal.tsx
+++ b/src/components/modals/RegionManagerModal.tsx
@@ -50,7 +50,7 @@ function RegionManagerModal({ onClose }: RegionManagerModalProps) {
       <div className="modal region-manager-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="region-manager-modal-title"><Icon name="map" size={18} /> Regions</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="region-manager-body">
           {/* Left panel: Region list */}
@@ -84,6 +84,7 @@ function RegionManagerModal({ onClose }: RegionManagerModalProps) {
                       className="region-delete-btn"
                       onClick={(e) => { e.stopPropagation(); handleDeleteRegion(region.id); }}
                       title="Delete region"
+                      aria-label="Delete region"
                     >
                       <Icon name="trash" size={12} />
                     </button>
@@ -126,8 +127,9 @@ function RegionEditor({ region, onUpdate, onEnterPaintMode, onClearHexes }: Regi
   return (
     <div>
       <div className="field-group">
-        <label>Name</label>
+        <label htmlFor="region-name">Name</label>
         <input
+          id="region-name"
           type="text"
           value={region.name}
           onChange={(e) => onUpdate({ name: e.target.value })}
@@ -137,8 +139,8 @@ function RegionEditor({ region, onUpdate, onEnterPaintMode, onClearHexes }: Regi
       </div>
 
       <div className="field-group">
-        <label>Color</label>
-        <div className="region-color-picker">
+        <label id="region-color-label">Color</label>
+        <div className="region-color-picker" role="group" aria-labelledby="region-color-label">
           {REGION_COLORS.map(color => (
             <button
               key={color}
@@ -146,21 +148,24 @@ function RegionEditor({ region, onUpdate, onEnterPaintMode, onClearHexes }: Regi
               style={{ backgroundColor: color }}
               onClick={() => onUpdate({ color })}
               title={color}
+              aria-label={`Color ${color}`}
             />
           ))}
           <input
+            id="region-color-custom"
             type="color"
             className="region-color-custom"
             value={region.color}
             onChange={(e) => onUpdate({ color: e.target.value })}
-            title="Custom color"
+            aria-label="Custom color"
           />
         </div>
       </div>
 
       <div className="field-group">
-        <label>Description</label>
+        <label htmlFor="region-description">Description</label>
         <textarea
+          id="region-description"
           value={region.description}
           onChange={(e) => onUpdate({ description: e.target.value })}
           placeholder="Describe this region..."
@@ -169,8 +174,9 @@ function RegionEditor({ region, onUpdate, onEnterPaintMode, onClearHexes }: Regi
       </div>
 
       <div className="field-group">
-        <label>Notes</label>
+        <label htmlFor="region-notes">Notes</label>
         <textarea
+          id="region-notes"
           value={region.notes}
           onChange={(e) => onUpdate({ notes: e.target.value })}
           placeholder="DM notes..."
@@ -179,8 +185,9 @@ function RegionEditor({ region, onUpdate, onEnterPaintMode, onClearHexes }: Regi
       </div>
 
       <div className="field-group">
-        <label>Tags</label>
+        <label htmlFor="region-tags">Tags</label>
         <input
+          id="region-tags"
           type="text"
           value={region.tags.join(', ')}
           onChange={(e) => {

--- a/src/components/modals/RelationshipWebModal.tsx
+++ b/src/components/modals/RelationshipWebModal.tsx
@@ -175,7 +175,7 @@ function RelationshipWebModal({ onClose }: RelationshipWebModalProps) {
       <div className="modal modal-xl relationship-web-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="relationship-web-modal-title"><Icon name="link" size={18} /> Relationship Web</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="relationship-web-body">
           <div className="relationship-web-controls">

--- a/src/components/modals/SessionLogModal.tsx
+++ b/src/components/modals/SessionLogModal.tsx
@@ -210,7 +210,7 @@ function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
               Export
             </button>
           </div>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
 
         {activeTab === 'sessions' && (
@@ -240,6 +240,7 @@ function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
                       className="btn-icon-small danger"
                       onClick={(e) => { e.stopPropagation(); deleteSession(session.id); }}
                       title="Delete session"
+                      aria-label="Delete session"
                     >
                       <Icon name="trash" size={12} />
                     </button>
@@ -285,6 +286,7 @@ function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
                 placeholder="Search entries..."
                 value={timelineSearch}
                 onChange={(e) => setTimelineSearch(e.target.value)}
+                aria-label="Search timeline entries"
               />
               <div className="tag-filter-bar">
                 {(Object.keys(SESSION_TAG_INFO) as SessionLogTag[]).map(tag => (
@@ -362,8 +364,9 @@ function SessionLogModal({ onClose, onNavigateToHex }: SessionLogModalProps) {
           <div className="session-log-body export-body">
             <div className="export-panel">
               <div className="field-group">
-                <label>Scope</label>
+                <label htmlFor="session-export-scope">Scope</label>
                 <select
+                  id="session-export-scope"
                   value={exportScope}
                   onChange={(e) => setExportScope(e.target.value as 'current' | 'all')}
                 >
@@ -435,8 +438,9 @@ function SessionEditor({
   return (
     <div className="session-editor">
       <div className="field-group">
-        <label>Title</label>
+        <label htmlFor="session-title">Title</label>
         <input
+          id="session-title"
           type="text"
           value={session.title}
           onChange={(e) => onUpdateSession({ ...session, title: e.target.value })}
@@ -444,8 +448,9 @@ function SessionEditor({
       </div>
 
       <div className="field-group">
-        <label>Real-World Date</label>
+        <label htmlFor="session-date">Real-World Date</label>
         <input
+          id="session-date"
           type="date"
           value={session.realWorldDate}
           onChange={(e) => onUpdateSession({ ...session, realWorldDate: e.target.value })}
@@ -453,8 +458,9 @@ function SessionEditor({
       </div>
 
       <div className="field-group">
-        <label>Summary</label>
+        <label htmlFor="session-summary">Summary</label>
         <textarea
+          id="session-summary"
           value={session.summary}
           onChange={(e) => onUpdateSession({ ...session, summary: e.target.value })}
           rows={3}
@@ -477,6 +483,7 @@ function SessionEditor({
                     hexesVisited: session.hexesVisited.filter(k => k !== key)
                   });
                 }}
+                aria-label={`Remove hex ${key}`}
               >
                 &times;
               </button>
@@ -490,6 +497,7 @@ function SessionEditor({
               onChange={(e) => setHexInput(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') addVisitedHex(); }}
               style={{ width: '60px', fontSize: '12px' }}
+              aria-label="Add hex coordinate"
             />
             <button className="btn btn-small" onClick={addVisitedHex}>+ Hex</button>
           </div>

--- a/src/components/modals/TerrainEditorModal.tsx
+++ b/src/components/modals/TerrainEditorModal.tsx
@@ -79,7 +79,7 @@ function TerrainEditorModal({ onClose }: TerrainEditorModalProps) {
       <div className="modal terrain-editor-modal" ref={focusTrapRef} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="terrain-editor-modal-title"><Icon name="hexagon" size={18} /> Terrain Types</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="terrain-editor-body">
           {/* Left panel: Terrain list */}
@@ -113,6 +113,7 @@ function TerrainEditorModal({ onClose }: TerrainEditorModalProps) {
                         className="terrain-delete-btn"
                         onClick={(e) => { e.stopPropagation(); handleDeleteClick(terrain.id); }}
                         title="Delete terrain type"
+                        aria-label="Delete terrain type"
                       >
                         <Icon name="trash" size={12} />
                       </button>
@@ -222,6 +223,7 @@ function TerrainEditor({ terrain, onUpdate, onRename }: TerrainEditorProps) {
               style={{ backgroundColor: color }}
               onClick={() => onUpdate({ colorHex: color })}
               title={color}
+              aria-label={`Color ${color}`}
             />
           ))}
           <input
@@ -243,6 +245,7 @@ function TerrainEditor({ terrain, onUpdate, onRename }: TerrainEditorProps) {
               className={`terrain-icon-option ${terrain.icon === iconName ? 'selected' : ''}`}
               onClick={() => onUpdate({ icon: iconName })}
               title={iconName}
+              aria-label={`Icon ${iconName}`}
             >
               <Icon name={iconName} size={16} />
             </button>

--- a/src/components/modals/TimeControlsModal.tsx
+++ b/src/components/modals/TimeControlsModal.tsx
@@ -129,8 +129,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
         <div className="modal-body">
           {/* Calendar Selection */}
           <div className="form-group">
-            <label>Calendar System</label>
+            <label htmlFor="time-calendar">Calendar System</label>
             <select
+              id="time-calendar"
               value={calendar.preset}
               onChange={(e) => handleCalendarChange(e.target.value as CalendarPreset)}
             >
@@ -163,8 +164,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
           <div className="time-controls-inputs">
             <div className="form-row">
               <div className="form-group">
-                <label>Year</label>
+                <label htmlFor="time-year">Year</label>
                 <input
+                  id="time-year"
                   type="number"
                   min={1}
                   value={time.year}
@@ -172,8 +174,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
                 />
               </div>
               <div className="form-group">
-                <label>Month</label>
+                <label htmlFor="time-month">Month</label>
                 <select
+                  id="time-month"
                   value={time.month}
                   onChange={(e) => handleMonthChange(parseInt(e.target.value))}
                 >
@@ -187,8 +190,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
             </div>
             <div className="form-row">
               <div className="form-group">
-                <label>Day</label>
+                <label htmlFor="time-day">Day</label>
                 <input
+                  id="time-day"
                   type="number"
                   min={1}
                   max={calendar.months[time.month]?.days || 30}
@@ -197,8 +201,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
                 />
               </div>
               <div className="form-group">
-                <label>Hour</label>
+                <label htmlFor="time-hour">Hour</label>
                 <input
+                  id="time-hour"
                   type="number"
                   min={0}
                   max={calendar.hoursPerDay - 1}
@@ -207,8 +212,9 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
                 />
               </div>
               <div className="form-group">
-                <label>Minute</label>
+                <label htmlFor="time-minute">Minute</label>
                 <input
+                  id="time-minute"
                   type="number"
                   min={0}
                   max={59}
@@ -251,6 +257,7 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
                   min={0}
                   value={customDays}
                   onChange={(e) => setCustomDays(parseInt(e.target.value) || 0)}
+                  aria-label="Custom advance days"
                 />
                 <span>days</span>
               </div>
@@ -260,6 +267,7 @@ function TimeControlsModal({ onClose }: TimeControlsModalProps) {
                   min={0}
                   value={customHours}
                   onChange={(e) => setCustomHours(parseInt(e.target.value) || 0)}
+                  aria-label="Custom advance hours"
                 />
                 <span>hours</span>
               </div>

--- a/src/components/modals/WeatherSettingsModal.tsx
+++ b/src/components/modals/WeatherSettingsModal.tsx
@@ -162,8 +162,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
             <h4>Set Custom Weather</h4>
 
             <div className="form-group">
-              <label>Condition</label>
+              <label htmlFor="weather-condition">Condition</label>
               <select
+                id="weather-condition"
                 value={weatherToEdit.condition}
                 onChange={(e) => handleConditionChange(e.target.value as WeatherCondition)}
               >
@@ -177,8 +178,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
 
             <div className="form-row">
               <div className="form-group">
-                <label>Temperature</label>
+                <label htmlFor="weather-temperature">Temperature</label>
                 <select
+                  id="weather-temperature"
                   value={weatherToEdit.temperature}
                   onChange={(e) => handleTemperatureChange(e.target.value as Temperature)}
                 >
@@ -191,8 +193,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
               </div>
 
               <div className="form-group">
-                <label>Wind</label>
+                <label htmlFor="weather-wind">Wind</label>
                 <select
+                  id="weather-wind"
                   value={weatherToEdit.wind}
                   onChange={(e) => handleWindChange(e.target.value as WindStrength)}
                 >
@@ -205,8 +208,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
               </div>
 
               <div className="form-group">
-                <label>Precipitation</label>
+                <label htmlFor="weather-precipitation">Precipitation</label>
                 <select
+                  id="weather-precipitation"
                   value={weatherToEdit.precipitation}
                   onChange={(e) => handlePrecipitationChange(e.target.value as PrecipitationLevel)}
                 >
@@ -267,8 +271,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
             <h4>Automatic Weather</h4>
 
             <div className="form-group form-checkbox">
-              <label>
+              <label htmlFor="weather-dynamic">
                 <input
+                  id="weather-dynamic"
                   type="checkbox"
                   checked={timeWeather.dynamicWeather}
                   onChange={(e) => handleDynamicToggle(e.target.checked)}
@@ -279,8 +284,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
             </div>
 
             <div className="form-group form-checkbox">
-              <label>
+              <label htmlFor="weather-seasonal">
                 <input
+                  id="weather-seasonal"
                   type="checkbox"
                   checked={timeWeather.seasonalEffects}
                   onChange={(e) => handleSeasonalToggle(e.target.checked)}
@@ -291,8 +297,9 @@ function WeatherSettingsModal({ onClose }: WeatherSettingsModalProps) {
             </div>
 
             <div className="form-group">
-              <label>Weather change interval (hours)</label>
+              <label htmlFor="weather-change-interval">Weather change interval (hours)</label>
               <input
+                id="weather-change-interval"
                 type="number"
                 min={1}
                 max={168}

--- a/src/components/npcs/FactionManager.tsx
+++ b/src/components/npcs/FactionManager.tsx
@@ -71,6 +71,7 @@ function FactionManager({ factions, allNpcs, onUpdate }: FactionManagerProps) {
                   className="faction-delete-btn"
                   onClick={(e) => { e.stopPropagation(); handleDelete(faction.id); }}
                   title="Delete faction"
+                  aria-label="Delete faction"
                 >
                   <Icon name="trash" size={12} />
                 </button>
@@ -128,6 +129,7 @@ function FactionEditor({ faction, memberCount, onUpdate }: FactionEditorProps) {
               style={{ backgroundColor: color }}
               onClick={() => onUpdate({ color })}
               title={color}
+              aria-label={`Color ${color}`}
             />
           ))}
           <input

--- a/src/components/npcs/NpcEditorModal.tsx
+++ b/src/components/npcs/NpcEditorModal.tsx
@@ -63,30 +63,30 @@ function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorMo
       <div ref={focusTrapRef} className="modal modal-lg npc-editor-modal" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3 id="npc-editor-modal-title">Edit NPC</h3>
-          <button className="close-btn" onClick={onClose}>&times;</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <div className="modal-body">
           {/* Basic Info */}
           <div className="field-group">
-            <label>Name</label>
-            <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
+            <label htmlFor="npc-name">Name</label>
+            <input id="npc-name" type="text" value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
           </div>
 
           <div className="field-row">
             <div className="field-group">
-              <label>Race</label>
-              <input type="text" value={race} onChange={(e) => setRace(e.target.value)} placeholder="e.g., Human, Elf, Dwarf" />
+              <label htmlFor="npc-race">Race</label>
+              <input id="npc-race" type="text" value={race} onChange={(e) => setRace(e.target.value)} placeholder="e.g., Human, Elf, Dwarf" />
             </div>
             <div className="field-group">
-              <label>Class</label>
-              <input type="text" value={npcClass} onChange={(e) => setNpcClass(e.target.value)} placeholder="e.g., Fighter, Wizard" />
+              <label htmlFor="npc-class">Class</label>
+              <input id="npc-class" type="text" value={npcClass} onChange={(e) => setNpcClass(e.target.value)} placeholder="e.g., Fighter, Wizard" />
             </div>
           </div>
 
           <div className="field-row">
             <div className="field-group">
-              <label>Alignment</label>
-              <select value={alignment} onChange={(e) => setAlignment(e.target.value as NpcAlignment | '')}>
+              <label htmlFor="npc-alignment">Alignment</label>
+              <select id="npc-alignment" value={alignment} onChange={(e) => setAlignment(e.target.value as NpcAlignment | '')}>
                 <option value="">None</option>
                 {ALIGNMENTS.map(a => (
                   <option key={a} value={a}>
@@ -96,8 +96,8 @@ function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorMo
               </select>
             </div>
             <div className="field-group">
-              <label>Attitude</label>
-              <select value={attitude} onChange={(e) => setAttitude(e.target.value as NpcAttitude | '')}>
+              <label htmlFor="npc-attitude">Attitude</label>
+              <select id="npc-attitude" value={attitude} onChange={(e) => setAttitude(e.target.value as NpcAttitude | '')}>
                 <option value="">None</option>
                 {ATTITUDES.map(a => (
                   <option key={a} value={a}>{ATTITUDE_INFO[a].label}</option>
@@ -107,24 +107,24 @@ function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorMo
           </div>
 
           <div className="field-group">
-            <label>Appearance</label>
-            <textarea value={appearance} onChange={(e) => setAppearance(e.target.value)} rows={2} placeholder="Physical description..." />
+            <label htmlFor="npc-appearance">Appearance</label>
+            <textarea id="npc-appearance" value={appearance} onChange={(e) => setAppearance(e.target.value)} rows={2} placeholder="Physical description..." />
           </div>
 
           <div className="field-group">
-            <label>Personality</label>
-            <textarea value={personality} onChange={(e) => setPersonality(e.target.value)} rows={2} placeholder="Personality traits, mannerisms..." />
+            <label htmlFor="npc-personality">Personality</label>
+            <textarea id="npc-personality" value={personality} onChange={(e) => setPersonality(e.target.value)} rows={2} placeholder="Personality traits, mannerisms..." />
           </div>
 
           <div className="field-group">
-            <label>Description</label>
-            <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={3} placeholder="Background, motivations..." />
+            <label htmlFor="npc-description">Description</label>
+            <textarea id="npc-description" value={description} onChange={(e) => setDescription(e.target.value)} rows={3} placeholder="Background, motivations..." />
           </div>
 
           <div className="field-row">
             <div className="field-group">
-              <label>Faction</label>
-              <select value={factionId} onChange={(e) => setFactionId(e.target.value)}>
+              <label htmlFor="npc-faction">Faction</label>
+              <select id="npc-faction" value={factionId} onChange={(e) => setFactionId(e.target.value)}>
                 <option value="">None</option>
                 {factions.map(f => (
                   <option key={f.id} value={f.id}>{f.name}</option>
@@ -132,19 +132,19 @@ function NpcEditorModal({ npc, factions, allNpcs, onSave, onClose }: NpcEditorMo
               </select>
             </div>
             <div className="field-group">
-              <label>Faction Role</label>
-              <input type="text" value={factionRole} onChange={(e) => setFactionRole(e.target.value)} placeholder="e.g., Leader, Spy, Member" />
+              <label htmlFor="npc-faction-role">Faction Role</label>
+              <input id="npc-faction-role" type="text" value={factionRole} onChange={(e) => setFactionRole(e.target.value)} placeholder="e.g., Leader, Spy, Member" />
             </div>
           </div>
 
           <div className="field-row">
             <div className="field-group">
-              <label>Difficulty / CR</label>
-              <input type="text" value={difficulty} onChange={(e) => setDifficulty(e.target.value)} placeholder="e.g., CR 5" />
+              <label htmlFor="npc-difficulty">Difficulty / CR</label>
+              <input id="npc-difficulty" type="text" value={difficulty} onChange={(e) => setDifficulty(e.target.value)} placeholder="e.g., CR 5" />
             </div>
             <div className="field-group">
-              <label>Tags (comma-separated)</label>
-              <input type="text" value={tags} onChange={(e) => setTags(e.target.value)} placeholder="e.g., quest-giver, merchant" />
+              <label htmlFor="npc-tags">Tags (comma-separated)</label>
+              <input id="npc-tags" type="text" value={tags} onChange={(e) => setTags(e.target.value)} placeholder="e.g., quest-giver, merchant" />
             </div>
           </div>
 

--- a/src/components/npcs/RelationshipEditor.tsx
+++ b/src/components/npcs/RelationshipEditor.tsx
@@ -73,6 +73,7 @@ function RelationshipEditor({ relationships, allNpcs, currentNpcId, onChange }: 
             className="btn-icon-small danger"
             onClick={() => removeRelationship(rel.targetNpcId)}
             title="Remove relationship"
+            aria-label="Remove relationship"
           >
             <Icon name="close" size={14} />
           </button>

--- a/src/components/quests/QuestDetailPanel.tsx
+++ b/src/components/quests/QuestDetailPanel.tsx
@@ -167,6 +167,7 @@ function QuestDetailPanel({
                 className="btn-icon-small danger"
                 onClick={() => removeObjective(obj.id)}
                 title="Remove objective"
+                aria-label="Remove objective"
               >
                 <Icon name="trash" size={12} />
               </button>
@@ -186,7 +187,7 @@ function QuestDetailPanel({
           {quest.linkedHexKeys.map(hk => (
             <span key={hk} className="quest-link-chip">
               ({hk})
-              <button className="chip-remove" onClick={() => removeHexLink(hk)}>&times;</button>
+              <button className="chip-remove" onClick={() => removeHexLink(hk)} aria-label={`Remove hex ${hk}`}>&times;</button>
             </span>
           ))}
           {quest.linkedHexKeys.length === 0 && (
@@ -205,7 +206,7 @@ function QuestDetailPanel({
             return (
               <span key={ref.npcId} className="quest-link-chip">
                 {entry?.npc.title || ref.npcId}
-                <button className="chip-remove" onClick={() => removeNpcLink(ref.npcId)}>&times;</button>
+                <button className="chip-remove" onClick={() => removeNpcLink(ref.npcId)} aria-label={`Remove NPC ${entry?.npc.title || ref.npcId}`}>&times;</button>
               </span>
             );
           })}
@@ -241,7 +242,7 @@ function QuestDetailPanel({
               <span key={f.id} className="quest-link-chip" style={{ borderColor: f.color }}>
                 <span className="quest-row-arc-dot" style={{ backgroundColor: f.color }} />
                 {f.name}
-                <button className="chip-remove" onClick={() => toggleFactionLink(f.id)}>&times;</button>
+                <button className="chip-remove" onClick={() => toggleFactionLink(f.id)} aria-label={`Remove faction ${f.name}`}>&times;</button>
               </span>
             ))}
           </div>
@@ -278,7 +279,7 @@ function QuestDetailPanel({
               return (
                 <span key={id} className="quest-link-chip">
                   {prereq?.title || id}
-                  <button className="chip-remove" onClick={() => togglePrerequisite(id)}>&times;</button>
+                  <button className="chip-remove" onClick={() => togglePrerequisite(id)} aria-label={`Remove prerequisite ${prereq?.title || id}`}>&times;</button>
                 </span>
               );
             })}

--- a/src/components/quests/StoryArcEditor.tsx
+++ b/src/components/quests/StoryArcEditor.tsx
@@ -68,6 +68,7 @@ function StoryArcEditor({ arc, quests, onUpdate, onDelete }: StoryArcEditorProps
               className={`story-arc-color-swatch ${arc.color === c ? 'selected' : ''}`}
               style={{ backgroundColor: c }}
               onClick={() => update({ color: c })}
+              aria-label={`Color ${c}`}
             />
           ))}
         </div>
@@ -123,6 +124,7 @@ function StoryArcEditor({ arc, quests, onUpdate, onDelete }: StoryArcEditorProps
                   disabled={idx === 0}
                   onClick={() => moveQuest(q.id, -1)}
                   title="Move up"
+                  aria-label="Move up"
                 >
                   <Icon name="chevron-right" size={12} className="rotate-270" />
                 </button>
@@ -131,6 +133,7 @@ function StoryArcEditor({ arc, quests, onUpdate, onDelete }: StoryArcEditorProps
                   disabled={idx === arcQuests.length - 1}
                   onClick={() => moveQuest(q.id, 1)}
                   title="Move down"
+                  aria-label="Move down"
                 >
                   <Icon name="chevron-down" size={12} />
                 </button>
@@ -138,6 +141,7 @@ function StoryArcEditor({ arc, quests, onUpdate, onDelete }: StoryArcEditorProps
                   className="btn-icon-small danger"
                   onClick={() => removeQuest(q.id)}
                   title="Remove from arc"
+                  aria-label="Remove from arc"
                 >
                   <Icon name="close" size={12} />
                 </button>

--- a/src/components/sessions/SessionEntryEditor.tsx
+++ b/src/components/sessions/SessionEntryEditor.tsx
@@ -50,7 +50,7 @@ function SessionEntryEditor({ entry, calendar, onChange, onDelete, onNavigateToH
         <span className="session-entry-time">
           <Icon name="clock" size={12} /> {timeDisplay}
         </span>
-        <button className="btn-icon-small danger" onClick={onDelete} title="Delete entry">
+        <button className="btn-icon-small danger" onClick={onDelete} title="Delete entry" aria-label="Delete entry">
           <Icon name="trash" size={14} />
         </button>
       </div>
@@ -107,6 +107,7 @@ function SessionEntryEditor({ entry, calendar, onChange, onDelete, onNavigateToH
               <button
                 className="hex-link-chip-remove"
                 onClick={(e) => { e.stopPropagation(); removeHexKey(key); }}
+                aria-label={`Remove hex ${key}`}
               >
                 &times;
               </button>


### PR DESCRIPTION
## Summary

Closes #25, #29. Depends on #35.

- **Form label associations (#25):** Added `htmlFor`+`id` pairs for standalone form labels, `aria-label` for inputs in repeating rows and unlabeled inputs
- **Icon-only button labels (#29):** Added `aria-label` to all buttons displaying only icons/symbols

### Form labels added across:
- GeneratorModal, EncounterEditorModal, NewCampaignModal, EncounterTemplateLibrary, SessionLogModal
- RegionManagerModal, EncounterTableEditorModal, LandmarkTableEditorModal, WeatherSettingsModal, TimeControlsModal
- NpcEditorModal, NpcLinker, CreatureList, RewardList, MainEditor

### Icon-only button labels added across:
- All modal close buttons, HexGrid zoom buttons, HexDetail action buttons
- Delete/remove buttons in table editors, terrain editor, region manager, session log
- Color swatch and icon picker buttons in terrain/region/story arc editors
- Action buttons in QuestDetailPanel, StoryArcEditor, RelationshipEditor, FactionManager, SessionEntryEditor

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 299 tests pass
- [ ] VoiceOver: Focus inputs → labels announced
- [ ] VoiceOver: Icon-only buttons → names announced

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/ringo380/hexal/36?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->