### PR TITLE
feat: actionable toast notifications with history panel

### DIFF
--- a/src/components/HexDetail.tsx
+++ b/src/components/HexDetail.tsx
@@ -243,15 +243,18 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
       ...currentHex,
       npcs: currentHex.npcs.filter(n => n.id !== npcToDelete.id)
     };
-    saveHex(updatedHex);
-    const hKey = `${selectedCoordinate.q},${selectedCoordinate.r}`;
-    const cleanup = deleteNpcCleanup(campaign, npcToDelete.id, hKey);
-    updateCampaignData(cleanup);
+    // Batch all changes into a single dispatch for one undo state
+    const hKey = toHexKey(selectedCoordinate);
+    const npcCleanup = deleteNpcCleanup(campaign, npcToDelete.id, hKey);
     const questCleanup = removeNpcFromQuests(campaign, npcToDelete.id);
-    updateCampaignData(questCleanup);
+    updateCampaignData({
+      hexes: { ...npcCleanup.hexes, [hKey]: updatedHex },
+      ...questCleanup,
+    });
+    setHex(updatedHex);
     toast(`${npcToDelete.title} deleted`, { variant: 'success', action: { label: 'Undo', onClick: undo } });
     setNpcToDelete(null);
-  }, [hex, selectedCoordinate, campaign, npcToDelete, getOrCreateHex, saveHex, updateCampaignData, toast, undo]);
+  }, [hex, selectedCoordinate, campaign, npcToDelete, getOrCreateHex, updateCampaignData, toast, undo]);
 
   const updateItem = useCallback((category: ContentCategory, updatedItem: ContentItem) => {
     if (!hex || !selectedCoordinate) return;
@@ -273,17 +276,24 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
       ...currentHex,
       [category]: currentHex[category].filter(item => item.id !== itemId)
     };
-    saveHex(updated);
+    // Batch hex update + quest cleanup into a single dispatch for one undo state
+    const hKey = toHexKey(selectedCoordinate);
+    let questCleanup = {};
     if (campaign) {
       if (category === 'encounters') {
-        updateCampaignData(removeEncounterFromQuests(campaign, itemId));
+        questCleanup = removeEncounterFromQuests(campaign, itemId);
       } else if (category === 'clues') {
-        updateCampaignData(removeClueFromQuests(campaign, itemId));
+        questCleanup = removeClueFromQuests(campaign, itemId);
       }
     }
+    updateCampaignData({
+      hexes: { ...(campaign?.hexes ?? {}), [hKey]: updated },
+      ...questCleanup,
+    });
+    setHex(updated);
     const label = deletedItem?.title || categoryConfig[category].title.replace(/s$/, '');
     toast(`${label} deleted`, { variant: 'success', action: { label: 'Undo', onClick: undo } });
-  }, [hex, selectedCoordinate, campaign, getOrCreateHex, saveHex, updateCampaignData, toast, undo]);
+  }, [hex, selectedCoordinate, campaign, getOrCreateHex, updateCampaignData, toast, undo]);
 
   const toggleResolved = useCallback((category: ContentCategory, itemId: string) => {
     if (!hex || !selectedCoordinate) return;

--- a/src/components/HexDetail.tsx
+++ b/src/components/HexDetail.tsx
@@ -6,6 +6,7 @@ import type { Hex, ContentItem, DiscoveryStatus, HexMarker, MarkerType, Npc } fr
 import { createContentItem, createNpc, createHex } from '../types';
 import type { Encounter, EncounterTemplate, ActiveEncounter } from '../types/Campaign';
 import { createEncounter, instantiateFromTemplate, hexKey as toHexKey } from '../types/Campaign';
+import { useToast } from '../stores/ToastContext';
 import { deleteNpcCleanup } from '../services/npcService';
 import { getQuestsForHex, removeNpcFromQuests, removeEncounterFromQuests, removeClueFromQuests } from '../services/questService';
 import { getEntriesForHex } from '../services/sessionLog';
@@ -77,9 +78,11 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
     removeHexFromRegion,
     getRegionForHex,
     sessions,
-    sessionLog
+    sessionLog,
+    undo
   } = useCampaign();
   const { selectedCoordinate, selectedMarker, selectMarker, regionPaintMode } = useHexSelection();
+  const toast = useToast();
   const weatherSim = useWeatherSimulation();
 
   const [hex, setHex] = useState<Hex | null>(null);
@@ -246,8 +249,9 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
     updateCampaignData(cleanup);
     const questCleanup = removeNpcFromQuests(campaign, npcToDelete.id);
     updateCampaignData(questCleanup);
+    toast(`${npcToDelete.title} deleted`, { variant: 'success', action: { label: 'Undo', onClick: undo } });
     setNpcToDelete(null);
-  }, [hex, selectedCoordinate, campaign, npcToDelete, getOrCreateHex, saveHex, updateCampaignData]);
+  }, [hex, selectedCoordinate, campaign, npcToDelete, getOrCreateHex, saveHex, updateCampaignData, toast, undo]);
 
   const updateItem = useCallback((category: ContentCategory, updatedItem: ContentItem) => {
     if (!hex || !selectedCoordinate) return;
@@ -264,6 +268,7 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
   const deleteItem = useCallback((category: ContentCategory, itemId: string) => {
     if (!hex || !selectedCoordinate) return;
     const currentHex = getOrCreateHex(selectedCoordinate);
+    const deletedItem = currentHex[category].find(item => item.id === itemId);
     const updated = {
       ...currentHex,
       [category]: currentHex[category].filter(item => item.id !== itemId)
@@ -276,7 +281,9 @@ function HexDetail({ onOpenQuestManager, onRevealEncounter }: HexDetailProps = {
         updateCampaignData(removeClueFromQuests(campaign, itemId));
       }
     }
-  }, [hex, selectedCoordinate, campaign, getOrCreateHex, saveHex, updateCampaignData]);
+    const label = deletedItem?.title || categoryConfig[category].title.replace(/s$/, '');
+    toast(`${label} deleted`, { variant: 'success', action: { label: 'Undo', onClick: undo } });
+  }, [hex, selectedCoordinate, campaign, getOrCreateHex, saveHex, updateCampaignData, toast, undo]);
 
   const toggleResolved = useCallback((category: ContentCategory, itemId: string) => {
     if (!hex || !selectedCoordinate) return;

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -80,7 +80,9 @@ export type IconName =
   // Status Icons
   | 'spinner'
   | 'alert-triangle'
-  | 'info';
+  | 'info'
+  // Notification Icons
+  | 'bell';
 
 const icons: Record<IconName, JSX.Element> = {
   'arrow-left': (
@@ -1532,6 +1534,33 @@ const icons: Record<IconName, JSX.Element> = {
       {/* Info symbol */}
       <path d="M12 16v-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
       <circle cx="12" cy="8" r="1" fill="currentColor" />
+    </>
+  ),
+  'bell': (
+    <>
+      {/* Secondary - bell body fill */}
+      <path
+        d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"
+        fill="var(--icon-secondary)"
+      />
+      {/* Primary - bell outline */}
+      <path
+        d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      {/* Clapper */}
+      <path
+        d="M13.73 21a2 2 0 0 1-3.46 0"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
     </>
   ),
 };

--- a/src/stores/ToastContext.tsx
+++ b/src/stores/ToastContext.tsx
@@ -7,6 +7,7 @@ import {
   createContext,
   useContext,
   useCallback,
+  useMemo,
   useRef,
   useState,
   useEffect,
@@ -191,14 +192,22 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setUnreadCount(0);
   }, []);
 
-  const contextValue: ToastContextValue = {
+  // Refresh timestamps periodically while history panel is open
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!showHistory) return;
+    const interval = setInterval(() => setTick((t) => t + 1), 15000);
+    return () => clearInterval(interval);
+  }, [showHistory]);
+
+  const contextValue = useMemo<ToastContextValue>(() => ({
     toast,
     history,
     unreadCount,
     showHistory,
     toggleHistory,
     clearHistory,
-  };
+  }), [toast, history, unreadCount, showHistory, toggleHistory, clearHistory]);
 
   return (
     <ToastContext.Provider value={contextValue}>

--- a/src/stores/ToastContext.tsx
+++ b/src/stores/ToastContext.tsx
@@ -1,5 +1,7 @@
 // ToastContext — Provides toast notifications via a portal-rendered UI.
 // Usage: const toast = useToast(); toast('Saved!', { variant: 'success' });
+// Action buttons: toast('Deleted', { variant: 'success', action: { label: 'Undo', onClick: handleUndo } });
+// History: const { history, unreadCount, showHistory, toggleHistory, clearHistory } = useToastHistory();
 
 import {
   createContext,
@@ -11,38 +13,91 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
+import Icon from '../components/icons/Icon';
 
 type ToastVariant = 'info' | 'success' | 'error' | 'warning';
+
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
 
 interface ToastOptions {
   variant?: ToastVariant;
   duration?: number;
+  action?: ToastAction;
 }
 
 interface ToastEntry {
   id: number;
   message: string;
   variant: ToastVariant;
+  action?: ToastAction;
   isExiting: boolean;
+}
+
+interface HistoryEntry {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+  timestamp: number;
 }
 
 type ToastFn = (message: string, options?: ToastOptions) => void;
 
+interface ToastContextValue {
+  toast: ToastFn;
+  history: HistoryEntry[];
+  unreadCount: number;
+  showHistory: boolean;
+  toggleHistory: () => void;
+  clearHistory: () => void;
+}
+
 const MAX_TOASTS = 3;
+const MAX_HISTORY = 50;
 const DEFAULT_DURATION = 4000;
 const ERROR_DURATION = 8000;
 const EXIT_ANIMATION_MS = 300;
 
-const ToastContext = createContext<ToastFn>(() => {});
+const ToastContext = createContext<ToastContextValue>({
+  toast: () => {},
+  history: [],
+  unreadCount: 0,
+  showHistory: false,
+  toggleHistory: () => {},
+  clearHistory: () => {},
+});
 
 export function useToast(): ToastFn {
-  return useContext(ToastContext);
+  return useContext(ToastContext).toast;
+}
+
+export function useToastHistory() {
+  const { history, unreadCount, showHistory, toggleHistory, clearHistory } =
+    useContext(ToastContext);
+  return { history, unreadCount, showHistory, toggleHistory, clearHistory };
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
 }
 
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
   const counterRef = useRef(0);
   const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const historyPanelRef = useRef<HTMLDivElement>(null);
+  const historyButtonRef = useRef<HTMLButtonElement>(null);
 
   // Cleanup all timers on unmount
   useEffect(() => {
@@ -50,6 +105,26 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       timersRef.current.forEach((timer) => clearTimeout(timer));
     };
   }, []);
+
+  // Outside-click dismissal for history panel (ref-based contains() per project conventions)
+  useEffect(() => {
+    if (!showHistory) return;
+
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        historyPanelRef.current &&
+        !historyPanelRef.current.contains(target) &&
+        historyButtonRef.current &&
+        !historyButtonRef.current.contains(target)
+      ) {
+        setShowHistory(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showHistory]);
 
   const dismiss = useCallback((id: number) => {
     // Start exit animation
@@ -73,7 +148,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       const duration = options.duration ?? (variant === 'error' ? ERROR_DURATION : DEFAULT_DURATION);
       const id = ++counterRef.current;
 
-      const entry: ToastEntry = { id, message, variant, isExiting: false };
+      const entry: ToastEntry = { id, message, variant, action: options.action, isExiting: false };
 
       setToasts((prev) => {
         const next = [...prev, entry];
@@ -88,6 +163,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         return next;
       });
 
+      // Add to history
+      setHistory((prev) => {
+        const histEntry: HistoryEntry = { id, message, variant, timestamp: Date.now() };
+        const next = [histEntry, ...prev];
+        if (next.length > MAX_HISTORY) next.length = MAX_HISTORY;
+        return next;
+      });
+      setUnreadCount((c) => c + 1);
+
       // Auto-dismiss timer
       const timer = setTimeout(() => dismiss(id), duration);
       timersRef.current.set(id, timer);
@@ -95,8 +179,29 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [dismiss],
   );
 
+  const toggleHistory = useCallback(() => {
+    setShowHistory((prev) => {
+      if (!prev) setUnreadCount(0);
+      return !prev;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+    setUnreadCount(0);
+  }, []);
+
+  const contextValue: ToastContextValue = {
+    toast,
+    history,
+    unreadCount,
+    showHistory,
+    toggleHistory,
+    clearHistory,
+  };
+
   return (
-    <ToastContext.Provider value={toast}>
+    <ToastContext.Provider value={contextValue}>
       {children}
       {createPortal(
         <div className="toast-container" role="log" aria-live="polite">
@@ -107,6 +212,17 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               role="status"
             >
               <span className="toast-message">{t.message}</span>
+              {t.action && (
+                <button
+                  className="toast-action"
+                  onClick={() => {
+                    t.action!.onClick();
+                    dismiss(t.id);
+                  }}
+                >
+                  {t.action.label}
+                </button>
+              )}
               <button
                 className="toast-dismiss"
                 onClick={() => dismiss(t.id)}
@@ -116,6 +232,52 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               </button>
             </div>
           ))}
+
+          {/* History toggle button */}
+          <button
+            ref={historyButtonRef}
+            className="toast-history-toggle"
+            onClick={toggleHistory}
+            aria-label="Notification history"
+          >
+            <Icon name="bell" size={16} />
+            {unreadCount > 0 && (
+              <span className="toast-history-badge">
+                {unreadCount > 99 ? '99+' : unreadCount}
+              </span>
+            )}
+          </button>
+
+          {/* History panel */}
+          {showHistory && (
+            <div ref={historyPanelRef} className="toast-history-panel">
+              <div className="toast-history-header">
+                <span>Notifications</span>
+                {history.length > 0 && (
+                  <button
+                    className="toast-history-clear"
+                    onClick={clearHistory}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <div className="toast-history-list">
+                {history.length === 0 ? (
+                  <div className="empty-hint" style={{ padding: '16px', textAlign: 'center' }}>
+                    No notifications yet
+                  </div>
+                ) : (
+                  history.map((h) => (
+                    <div key={h.id} className={`toast-history-item toast-history-item--${h.variant}`}>
+                      <span className="toast-history-message">{h.message}</span>
+                      <span className="toast-history-time">{formatTimeAgo(h.timestamp)}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
         </div>,
         document.body,
       )}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -6281,6 +6281,154 @@ label {
   animation: toastFadeOut 0.3s ease-in forwards;
 }
 
+.toast-action {
+  background: none;
+  border: none;
+  color: #4a9eff;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  flex-shrink: 0;
+  border-radius: 3px;
+}
+
+.toast-action:hover {
+  background: rgba(74, 158, 255, 0.15);
+}
+
+/* Toast history toggle button */
+.toast-history-toggle {
+  align-self: flex-end;
+  position: relative;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  pointer-events: auto;
+  color: #888;
+  margin-top: 4px;
+}
+
+.toast-history-toggle:hover {
+  color: #ccc;
+  border-color: #666;
+}
+
+.toast-history-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #4a9eff;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+/* Toast history panel */
+.toast-history-panel {
+  position: absolute;
+  bottom: 48px;
+  right: 0;
+  width: 320px;
+  max-height: 360px;
+  background: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.toast-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid #383838;
+  font-size: 13px;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.toast-history-clear {
+  background: none;
+  border: none;
+  color: #4a9eff;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.toast-history-clear:hover {
+  background: rgba(74, 158, 255, 0.15);
+}
+
+.toast-history-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.toast-history-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid #333;
+  font-size: 12px;
+  border-left: 3px solid transparent;
+}
+
+.toast-history-item:last-child {
+  border-bottom: none;
+}
+
+.toast-history-item--info {
+  border-left-color: #4a9eff;
+}
+
+.toast-history-item--success {
+  border-left-color: #4caf50;
+}
+
+.toast-history-item--error {
+  border-left-color: #f44336;
+}
+
+.toast-history-item--warning {
+  border-left-color: #ff9800;
+}
+
+.toast-history-message {
+  color: #ccc;
+  flex: 1;
+  line-height: 1.4;
+}
+
+.toast-history-time {
+  color: #666;
+  font-size: 11px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
 /* ============ ERROR BOUNDARY ============ */
 
 .error-boundary {


### PR DESCRIPTION
## Summary
- Add optional action buttons on toasts (e.g., "Undo" on delete operations) with auto-dismiss on click
- Add notification history panel with bell icon toggle, unread badge, relative timestamps, variant-colored entries, and clear button
- Wire undo actions into hex content delete and NPC delete handlers as usage examples
- New `useToastHistory()` hook; existing `useToast()` API unchanged (backward-compatible)

Closes #59

## Test plan
- [ ] Trigger toast without action — renders as before (no regression)
- [ ] Delete a hex content item — toast shows with "Undo" button
- [ ] Click "Undo" — item restored, toast dismisses
- [ ] Delete an NPC — toast shows with "Undo" button
- [ ] Bell icon visible in bottom-right corner
- [ ] Badge shows unread count after toasts fire
- [ ] Click bell — history panel opens with past notifications
- [ ] Relative timestamps display correctly (just now, Xs ago, Xm ago)
- [ ] "Clear" button empties history list
- [ ] Outside click closes history panel
- [ ] Verify max 50 history entries (oldest trimmed)
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (487 tests)