### PR TITLE
feat: offline-first sync with merge resolution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,10 @@ import MainEditor from './components/MainEditor';
 import { WeatherSimulationProvider } from './stores/WeatherSimulationContext';
 import UnsavedChangesDialog from './components/modals/UnsavedChangesDialog';
 import AlertDialog from './components/modals/AlertDialog';
+import ConflictResolutionModal from './components/modals/ConflictResolutionModal';
 import { filterCampaignForPlayer } from './services/playerViewFilter';
 import ErrorBoundary from './components/ErrorBoundary';
+import { useSyncContext } from './stores/SyncContext';
 
 type PendingAction = {
   type: 'open' | 'open-new-window' | 'new-campaign';
@@ -19,6 +21,7 @@ function App() {
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { pendingConflict, resolveConflict } = useSyncContext();
   const exportRef = useRef<(() => void) | null>(null);
   const mapExportRef = useRef<(() => void) | null>(null);
   const exportTemplateRef = useRef<(() => void) | null>(null);
@@ -275,6 +278,13 @@ function App() {
           message={errorMessage}
           variant="error"
           onClose={() => setErrorMessage(null)}
+        />
+      )}
+
+      {pendingConflict && (
+        <ConflictResolutionModal
+          conflict={pendingConflict}
+          onResolve={resolveConflict}
         />
       )}
     </div>

--- a/src/components/modals/ConflictResolutionModal.tsx
+++ b/src/components/modals/ConflictResolutionModal.tsx
@@ -65,9 +65,9 @@ function HexConflictList({ hexConflicts }: { hexConflicts: HexConflict[] }) {
         aria-label={`${hexConflicts.length} hex conflicts, click to ${expanded ? 'collapse' : 'expand'}`}
       >
         <span className="conflict-toggle-icon">{expanded ? '\u25BC' : '\u25B6'}</span>
-        <h4 className="conflict-section-title">
+        <span className="conflict-section-title">
           Hex Conflicts ({hexConflicts.length})
-        </h4>
+        </span>
       </button>
       {expanded && (
         <ul className="conflict-hex-list">
@@ -98,7 +98,6 @@ function AutoMergedSummary({ count }: { count: number }) {
 
 function ConflictResolutionModal({ conflict, onResolve }: ConflictResolutionModalProps) {
   const [resolving, setResolving] = useState(false);
-  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: undefined });
 
   const handleResolve = async (resolution: ConflictResolution) => {
     setResolving(true);
@@ -108,6 +107,14 @@ function ConflictResolutionModal({ conflict, onResolve }: ConflictResolutionModa
       setResolving(false);
     }
   };
+
+  // Escape dismisses by accepting remote changes (safe default — no data push)
+  const handleEscape = () => {
+    if (!resolving) {
+      handleResolve({ strategy: 'keep-remote' });
+    }
+  };
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: handleEscape });
 
   const hasMetadataDiffs = conflict.metadataDiffs.length > 0;
   const hasHexConflicts = conflict.hexConflicts.length > 0;

--- a/src/components/modals/ConflictResolutionModal.tsx
+++ b/src/components/modals/ConflictResolutionModal.tsx
@@ -1,0 +1,179 @@
+// ConflictResolutionModal — Presents sync conflicts and lets the user choose
+// a resolution strategy: keep local changes, accept remote changes, or merge.
+
+import { useState } from 'react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import type { CampaignConflict, ConflictResolution } from '../../types/Sync';
+import type { FieldDiff, HexConflict } from '../../types/Sync';
+
+interface ConflictResolutionModalProps {
+  conflict: CampaignConflict;
+  onResolve: (resolution: ConflictResolution) => Promise<void>;
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null) return '(empty)';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) return `${value.length} items`;
+  return 'Modified';
+}
+
+function MetadataDiffTable({ diffs }: { diffs: FieldDiff[] }) {
+  if (diffs.length === 0) return null;
+
+  return (
+    <div className="conflict-section">
+      <h4 className="conflict-section-title">Campaign Changes</h4>
+      <table className="conflict-diff-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Your Version</th>
+            <th>Their Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          {diffs.map(diff => (
+            <tr key={diff.field}>
+              <td className="conflict-field-label">{diff.label}</td>
+              <td className="conflict-value conflict-value--local">
+                {formatValue(diff.localValue)}
+              </td>
+              <td className="conflict-value conflict-value--remote">
+                {formatValue(diff.remoteValue)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HexConflictList({ hexConflicts }: { hexConflicts: HexConflict[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (hexConflicts.length === 0) return null;
+
+  return (
+    <div className="conflict-section">
+      <button
+        className="conflict-section-toggle"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={`${hexConflicts.length} hex conflicts, click to ${expanded ? 'collapse' : 'expand'}`}
+      >
+        <span className="conflict-toggle-icon">{expanded ? '\u25BC' : '\u25B6'}</span>
+        <h4 className="conflict-section-title">
+          Hex Conflicts ({hexConflicts.length})
+        </h4>
+      </button>
+      {expanded && (
+        <ul className="conflict-hex-list">
+          {hexConflicts.map(hc => (
+            <li key={hc.hexKey} className="conflict-hex-item">
+              <span className="conflict-hex-key">Hex {hc.hexKey}</span>
+              <span className="conflict-hex-detail">
+                Both versions modified terrain, content, or status
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function AutoMergedSummary({ count }: { count: number }) {
+  if (count === 0) return null;
+
+  return (
+    <div className="conflict-section conflict-auto-merged">
+      <span className="conflict-auto-merged-icon">{'\u2713'}</span>
+      {count} hex{count === 1 ? '' : 'es'} with non-overlapping changes merged automatically
+    </div>
+  );
+}
+
+function ConflictResolutionModal({ conflict, onResolve }: ConflictResolutionModalProps) {
+  const [resolving, setResolving] = useState(false);
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: undefined });
+
+  const handleResolve = async (resolution: ConflictResolution) => {
+    setResolving(true);
+    try {
+      await onResolve(resolution);
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  const hasMetadataDiffs = conflict.metadataDiffs.length > 0;
+  const hasHexConflicts = conflict.hexConflicts.length > 0;
+  const hasAutoMerged = conflict.autoMergedHexKeys.length > 0;
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="conflict-modal-title"
+    >
+      <div ref={focusTrapRef} className="modal conflict-resolution-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h3 id="conflict-modal-title">Sync Conflict Detected</h3>
+        </div>
+        <div className="modal-body">
+          <p className="conflict-description">
+            Another device updated this campaign while you were editing.
+            Choose how to resolve the conflict.
+          </p>
+
+          <div className="conflict-version-info">
+            <span>Your version: {conflict.localVersion}</span>
+            <span>Server version: {conflict.remoteVersion}</span>
+          </div>
+
+          {hasMetadataDiffs && (
+            <MetadataDiffTable diffs={conflict.metadataDiffs} />
+          )}
+
+          {hasHexConflicts && (
+            <HexConflictList hexConflicts={conflict.hexConflicts} />
+          )}
+
+          {hasAutoMerged && (
+            <AutoMergedSummary count={conflict.autoMergedHexKeys.length} />
+          )}
+
+          {!hasMetadataDiffs && !hasHexConflicts && !hasAutoMerged && (
+            <p className="empty-hint">
+              Version mismatch detected but no field-level differences found.
+            </p>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button
+            className="btn btn-primary"
+            onClick={() => handleResolve({ strategy: 'keep-local' })}
+            disabled={resolving}
+            aria-label="Keep your local changes"
+          >
+            {resolving ? 'Resolving...' : 'Keep Mine'}
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={() => handleResolve({ strategy: 'keep-remote' })}
+            disabled={resolving}
+            aria-label="Accept remote changes"
+          >
+            Keep Theirs
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConflictResolutionModal;

--- a/src/components/ui/ConnectionStatus.tsx
+++ b/src/components/ui/ConnectionStatus.tsx
@@ -1,12 +1,20 @@
-// ConnectionStatus — Toolbar indicator for online/offline and sync state.
-// Currently reads navigator.onLine only. Sync status will be integrated
-// when the cloud sync engine is wired up.
+// ConnectionStatus — Toolbar indicator for sync state.
+// Reads from SyncContext when cloud sync is enabled, falls back to
+// navigator.onLine for local-only mode.
 
 import { useState, useEffect } from 'react';
+import { useSyncContext } from '../../stores/SyncContext';
 
-type Status = 'synced' | 'syncing' | 'offline' | 'conflict' | 'error';
+const STATUS_CONFIG = {
+  synced:   { label: 'Synced',    dotClass: 'connection-dot--synced' },
+  syncing:  { label: 'Syncing...', dotClass: 'connection-dot--syncing' },
+  offline:  { label: 'Offline',   dotClass: 'connection-dot--offline' },
+  conflict: { label: 'Conflict',  dotClass: 'connection-dot--conflict' },
+  error:    { label: 'Sync Error', dotClass: 'connection-dot--error' },
+} as const;
 
 function ConnectionStatus() {
+  const { syncStatus, queueCount } = useSyncContext();
   const [online, setOnline] = useState(navigator.onLine);
 
   useEffect(() => {
@@ -20,15 +28,29 @@ function ConnectionStatus() {
     };
   }, []);
 
-  // For now, status is derived solely from navigator.onLine.
-  // Once the sync engine is integrated, this will read from a SyncContext
-  // that provides granular status: synced | syncing | offline | conflict | error.
-  const status: Status = online ? 'synced' : 'offline';
-  const label = online ? 'Online' : 'Offline';
+  // Use sync status when available, otherwise derive from navigator.onLine
+  const effectiveStatus = syncStatus;
+  const config = STATUS_CONFIG[effectiveStatus];
+
+  // Append pending count for offline status
+  let label: string = config.label;
+  if (effectiveStatus === 'offline' && queueCount > 0) {
+    label = `Offline (${queueCount} pending)`;
+  }
+
+  // In local-only mode (no SyncProvider), show basic online/offline
+  if (!online && effectiveStatus === 'synced') {
+    return (
+      <div className="connection-status" title="Offline">
+        <span className="connection-dot connection-dot--offline" />
+        <span>Offline</span>
+      </div>
+    );
+  }
 
   return (
     <div className="connection-status" title={label}>
-      <span className={`connection-dot connection-dot--${status}`} />
+      <span className={`connection-dot ${config.dotClass}`} />
       <span>{label}</span>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import { AuthProvider } from './stores/AuthContext';
 import { AnnouncerProvider } from './stores/AnnouncerContext';
 import { ToastProvider } from './stores/ToastContext';
 import { createPersistenceAdapter } from './services/persistence';
+import { SyncProvider } from './stores/SyncContext';
 import { ClerkProvider } from '@clerk/react';
 import './styles/app.css';
 import './styles/auth.css';
@@ -32,6 +33,24 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY}>
           <SettingsProvider>
             <AuthProvider clerkEnabled>
+              <SyncProvider engine={null}>
+                <CampaignProvider adapter={persistenceAdapter}>
+                  <SelectionProvider>
+                    <AnnouncerProvider>
+                      <ToastProvider>
+                        <App />
+                      </ToastProvider>
+                    </AnnouncerProvider>
+                  </SelectionProvider>
+                </CampaignProvider>
+              </SyncProvider>
+            </AuthProvider>
+          </SettingsProvider>
+        </ClerkProvider>
+      ) : (
+        <SettingsProvider>
+          <AuthProvider>
+            <SyncProvider engine={null}>
               <CampaignProvider adapter={persistenceAdapter}>
                 <SelectionProvider>
                   <AnnouncerProvider>
@@ -41,21 +60,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
                   </AnnouncerProvider>
                 </SelectionProvider>
               </CampaignProvider>
-            </AuthProvider>
-          </SettingsProvider>
-        </ClerkProvider>
-      ) : (
-        <SettingsProvider>
-          <AuthProvider>
-            <CampaignProvider adapter={persistenceAdapter}>
-              <SelectionProvider>
-                <AnnouncerProvider>
-                  <ToastProvider>
-                    <App />
-                  </ToastProvider>
-                </AnnouncerProvider>
-              </SelectionProvider>
-            </CampaignProvider>
+            </SyncProvider>
           </AuthProvider>
         </SettingsProvider>
       )}

--- a/src/services/cloudStorage.ts
+++ b/src/services/cloudStorage.ts
@@ -290,6 +290,78 @@ export async function saveCloudCampaign(
   return {};
 }
 
+/** Result from a version-checked save attempt. */
+export interface VersionedSaveResult {
+  error?: string;
+  conflict?: boolean;
+  serverVersion?: number;
+  newVersion?: number;
+}
+
+/**
+ * Save a campaign with optimistic concurrency control via the
+ * upsert_campaign_versioned RPC. Rejects the write if the server's
+ * current version doesn't match expectedVersion.
+ */
+export async function saveCloudCampaignVersioned(
+  client: SupabaseClient,
+  campaign: Campaign,
+  userId: string,
+  expectedVersion: number
+): Promise<VersionedSaveResult> {
+  // Build hex rows as JSON for the RPC
+  const hexRows = Object.entries(campaign.hexes).map(([hexKey, hex]) => ({
+    hex_key: hexKey,
+    data: hex,
+  }));
+
+  // Build region rows as JSON for the RPC
+  const regionRows = (campaign.regions ?? []).map(region => ({
+    name: region.name,
+    color: region.color,
+    description: region.description ?? '',
+    hexKeys: region.hexKeys ?? [],
+    tags: region.tags ?? [],
+    isDiscovered: region.isDiscovered ?? false,
+    notes: region.notes ?? '',
+  }));
+
+  const { data, error } = await client.rpc('upsert_campaign_versioned', {
+    p_id: campaign.id,
+    p_owner_id: userId,
+    p_name: campaign.name,
+    p_grid_width: campaign.gridWidth,
+    p_grid_height: campaign.gridHeight,
+    p_terrain_types: campaign.terrainTypes,
+    p_encounter_tables: campaign.encounterTables,
+    p_time_weather: campaign.timeWeather ?? null,
+    p_marker_types: campaign.markerTypes ?? null,
+    p_encounter_templates: campaign.encounterTemplates ?? [],
+    p_bookmarked_hexes: campaign.bookmarkedHexes ?? [],
+    p_generation_config: campaign.generationConfig ?? null,
+    p_landmark_tables: campaign.landmarkTables ?? [],
+    p_factions: campaign.factions ?? [],
+    p_sessions: campaign.sessions ?? [],
+    p_session_log: campaign.sessionLog ?? [],
+    p_schema_version: campaign.schemaVersion ?? CAMPAIGN_SCHEMA_VERSION,
+    p_expected_version: expectedVersion,
+    p_last_modified_by: userId,
+    p_hex_rows: hexRows,
+    p_region_rows: regionRows,
+  });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  const result = data as { conflict: boolean; new_version?: number; server_version?: number };
+  if (result.conflict) {
+    return { conflict: true, serverVersion: result.server_version };
+  }
+
+  return { conflict: false, newVersion: result.new_version };
+}
+
 /**
  * Delete a campaign (cascade handles hexes/regions via Supabase FK rules).
  */

--- a/src/services/conflictResolver.ts
+++ b/src/services/conflictResolver.ts
@@ -1,0 +1,159 @@
+// conflictResolver — Computes diffs between local and remote campaign states
+// and assembles merged campaigns from user resolution choices.
+
+import type { Campaign, Hex } from '../types';
+import type { CampaignConflict, FieldDiff, HexConflict } from '../types/Sync';
+
+// Campaign metadata fields to compare (excludes hexes, id, version, timestamps).
+const METADATA_FIELDS: Array<{ field: keyof Campaign; label: string }> = [
+  { field: 'name', label: 'Name' },
+  { field: 'gridWidth', label: 'Grid Width' },
+  { field: 'gridHeight', label: 'Grid Height' },
+  { field: 'terrainTypes', label: 'Terrain Types' },
+  { field: 'encounterTables', label: 'Encounter Tables' },
+  { field: 'timeWeather', label: 'Time & Weather' },
+  { field: 'markerTypes', label: 'Marker Types' },
+  { field: 'encounterTemplates', label: 'Encounter Templates' },
+  { field: 'bookmarkedHexes', label: 'Bookmarked Hexes' },
+  { field: 'regions', label: 'Regions' },
+  { field: 'generationConfig', label: 'Generation Config' },
+  { field: 'landmarkTables', label: 'Landmark Tables' },
+  { field: 'factions', label: 'Factions' },
+  { field: 'sessions', label: 'Sessions' },
+  { field: 'sessionLog', label: 'Session Log' },
+  { field: 'quests', label: 'Quests' },
+  { field: 'storyArcs', label: 'Story Arcs' },
+  { field: 'weatherSimulation', label: 'Weather Simulation' },
+  { field: 'fogOfWarConfig', label: 'Fog of War Config' },
+  { field: 'playerCharacters', label: 'Player Characters' },
+  { field: 'parties', label: 'Parties' },
+  { field: 'playerNotes', label: 'Player Notes' },
+  { field: 'partyPosition', label: 'Party Position' },
+  { field: 'travelLog', label: 'Travel Log' },
+];
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Compute the full conflict description between local and remote campaigns.
+ * Categorizes changes into metadata diffs, hex conflicts, and auto-mergeable hex changes.
+ */
+export function computeCampaignConflict(
+  local: Campaign,
+  remote: Campaign
+): CampaignConflict {
+  // Compare metadata fields
+  const metadataDiffs: FieldDiff[] = [];
+  for (const { field, label } of METADATA_FIELDS) {
+    const localVal = local[field];
+    const remoteVal = remote[field];
+    if (!jsonEqual(localVal, remoteVal)) {
+      metadataDiffs.push({
+        field,
+        label,
+        localValue: localVal,
+        remoteValue: remoteVal,
+      });
+    }
+  }
+
+  // Compare hexes
+  const hexConflicts: HexConflict[] = [];
+  const autoMergedHexKeys: string[] = [];
+
+  const localKeys = new Set(Object.keys(local.hexes));
+  const remoteKeys = new Set(Object.keys(remote.hexes));
+
+  // Hexes only in local — auto-merge (local addition)
+  localKeys.forEach(key => {
+    if (!remoteKeys.has(key)) {
+      autoMergedHexKeys.push(key);
+    }
+  });
+
+  // Hexes only in remote — auto-merge (remote addition)
+  remoteKeys.forEach(key => {
+    if (!localKeys.has(key)) {
+      autoMergedHexKeys.push(key);
+    }
+  });
+
+  // Hexes in both — compare content
+  localKeys.forEach(key => {
+    if (remoteKeys.has(key)) {
+      const localHex = local.hexes[key];
+      const remoteHex = remote.hexes[key];
+      if (!jsonEqual(localHex, remoteHex)) {
+        hexConflicts.push({ hexKey: key, localHex, remoteHex });
+      }
+    }
+  });
+
+  return {
+    campaignId: local.id,
+    localVersion: local.version ?? 0,
+    remoteVersion: remote.version ?? 0,
+    localCampaign: local,
+    remoteCampaign: remote,
+    metadataDiffs,
+    hexConflicts,
+    autoMergedHexKeys,
+  };
+}
+
+/**
+ * Build a merged campaign from conflict resolution choices.
+ *
+ * @param conflict - The computed conflict
+ * @param metadataChoices - For each differing metadata field, 'local' or 'remote'
+ * @param hexChoices - For each conflicting hex key, 'local' or 'remote'
+ */
+export function buildMergedCampaign(
+  conflict: CampaignConflict,
+  metadataChoices: Record<string, 'local' | 'remote'>,
+  hexChoices: Record<string, 'local' | 'remote'>
+): Campaign {
+  const { localCampaign, remoteCampaign } = conflict;
+
+  // Start from local as base
+  const merged: Campaign = { ...localCampaign };
+
+  // Apply metadata choices
+  for (const diff of conflict.metadataDiffs) {
+    const choice = metadataChoices[diff.field] ?? 'local';
+    if (choice === 'remote') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (merged as any)[diff.field] = diff.remoteValue;
+    }
+  }
+
+  // Build merged hex record
+  const mergedHexes: Record<string, Hex> = {};
+
+  // Include all hexes from local
+  for (const [key, hex] of Object.entries(localCampaign.hexes)) {
+    mergedHexes[key] = hex;
+  }
+
+  // Include hexes only in remote (auto-merged additions)
+  for (const key of conflict.autoMergedHexKeys) {
+    if (remoteCampaign.hexes[key] && !localCampaign.hexes[key]) {
+      mergedHexes[key] = remoteCampaign.hexes[key];
+    }
+  }
+
+  // Apply hex conflict choices
+  for (const hc of conflict.hexConflicts) {
+    const choice = hexChoices[hc.hexKey] ?? 'local';
+    mergedHexes[hc.hexKey] = choice === 'remote' ? hc.remoteHex : hc.localHex;
+  }
+
+  merged.hexes = mergedHexes;
+
+  // Use the remote version so the next save passes the version check
+  merged.version = conflict.remoteVersion;
+
+  return merged;
+}

--- a/src/services/localCache.ts
+++ b/src/services/localCache.ts
@@ -149,9 +149,6 @@ export async function clearSyncQueue(ids: number[]): Promise<void> {
 }
 
 /**
- * Remove all cached data for a campaign: campaign entry, hexes, and queue entries.
- */
-/**
  * Update the base snapshot for a campaign — the last state confirmed synced
  * with the server. Called after a successful remote save or remote load.
  */

--- a/src/services/localCache.ts
+++ b/src/services/localCache.ts
@@ -10,9 +10,10 @@ import type { Campaign } from '../types';
 /** Cached campaign metadata and full data */
 export interface CachedCampaign {
   id: string;           // campaign UUID (primary key)
-  data: unknown;        // full Campaign object
+  data: unknown;        // full Campaign object (working local copy)
   version: number;      // last known server version
   lastSynced: number;   // timestamp ms
+  lastSyncedData?: unknown; // campaign snapshot at last confirmed remote sync (base for 3-way diff)
 }
 
 /** Cached hex data (individual hex granularity) */
@@ -46,6 +47,12 @@ class HexalCache extends Dexie {
   constructor() {
     super('hexal-cache');
     this.version(1).stores({
+      campaigns: 'id',
+      hexes: 'id, campaignId',
+      syncQueue: '++id, campaignId, type',
+    });
+    // v2: adds lastSyncedData field to campaigns (no index change needed)
+    this.version(2).stores({
       campaigns: 'id',
       hexes: 'id, campaignId',
       syncQueue: '++id, campaignId, type',
@@ -139,6 +146,39 @@ export async function getSyncQueue(campaignId?: string): Promise<SyncQueueEntry[
  */
 export async function clearSyncQueue(ids: number[]): Promise<void> {
   await cache.syncQueue.bulkDelete(ids);
+}
+
+/**
+ * Remove all cached data for a campaign: campaign entry, hexes, and queue entries.
+ */
+/**
+ * Update the base snapshot for a campaign — the last state confirmed synced
+ * with the server. Called after a successful remote save or remote load.
+ */
+export async function updateBaseSnapshot(campaignId: string, campaign: Campaign): Promise<void> {
+  const existing = await cache.campaigns.get(campaignId);
+  if (existing) {
+    await cache.campaigns.update(campaignId, { lastSyncedData: campaign });
+  }
+}
+
+/**
+ * Retrieve the base snapshot (last confirmed server state) for a campaign.
+ * Returns null if no base snapshot exists (first sync or never synced).
+ */
+export async function getBaseSnapshot(campaignId: string): Promise<Campaign | null> {
+  const entry = await cache.campaigns.get(campaignId);
+  return (entry?.lastSyncedData as Campaign) ?? null;
+}
+
+/**
+ * Get the number of pending sync queue entries, optionally filtered by campaign.
+ */
+export async function getSyncQueueCount(campaignId?: string): Promise<number> {
+  if (campaignId) {
+    return cache.syncQueue.where('campaignId').equals(campaignId).count();
+  }
+  return cache.syncQueue.count();
 }
 
 /**

--- a/src/services/persistence/cloudAdapter.ts
+++ b/src/services/persistence/cloudAdapter.ts
@@ -38,7 +38,7 @@ export class CloudPersistenceAdapter implements PersistenceAdapter {
     }));
   }
 
-  async save(campaign: Campaign, _identifier?: string): Promise<SaveResult> {
+  async save(campaign: Campaign, _identifier?: string, _options?: { compact?: boolean }): Promise<SaveResult> {
     try {
       // Always cache locally first
       await cacheCampaign(campaign, campaign.version ?? 1);
@@ -84,18 +84,43 @@ export class CloudPersistenceAdapter implements PersistenceAdapter {
     }
   }
 
-  onRemoteChange(callback: (campaign: Campaign) => void): () => void {
+  onRemoteChange(_callback: (campaign: Campaign) => void): () => void {
+    // No-op when campaignId is unknown — use subscribeToRemoteChanges instead
+    return () => {};
+  }
+
+  /**
+   * Subscribe to Realtime changes for a specific campaign.
+   * Call this when a campaign is loaded and the ID is known.
+   * Returns an unsubscribe function.
+   *
+   * @param campaignId - The UUID of the loaded campaign
+   * @param onCampaignUpdate - Called with the full campaign when a remote change arrives
+   * @param onVersionConflict - Called when remote version is higher than local
+   */
+  subscribeToRemoteChanges(
+    campaignId: string,
+    onCampaignUpdate: (campaign: Campaign) => void,
+    onVersionConflict?: (remoteVersion: number) => void
+  ): () => void {
+    if (!campaignId) return () => {};
+
     return subscribeToChanges(
       this.client,
-      '', // Campaign ID not known at subscribe time — callers should subscribe per-campaign
+      campaignId,
       (_hexPayload: HexChangePayload) => {
         // Hex-level changes handled by sync engine, not here
       },
       async (campaignPayload: CampaignChangePayload) => {
+        // Notify about the version change
+        if (onVersionConflict) {
+          onVersionConflict(campaignPayload.version);
+        }
+
         // Reload full campaign on campaign-level change
         const result = await loadCloudCampaign(this.client, campaignPayload.campaignId);
         if (result.campaign) {
-          callback(migrateCampaign(result.campaign));
+          onCampaignUpdate(migrateCampaign(result.campaign));
         }
       }
     );

--- a/src/services/syncEngine.ts
+++ b/src/services/syncEngine.ts
@@ -59,23 +59,17 @@ function coalesceQueue(entries: SyncQueueEntry[]): SyncQueueEntry[] {
     }
   }
 
-  // Rebuild: campaign entries first, then hex entries, preserving campaign order
+  // Rebuild: campaign entries first, then hex entries
   const result: SyncQueueEntry[] = [];
-  const allIds = new Set<number>();
 
-  // Campaign entries first
   Array.from(campaignMap.values()).forEach(entry => {
     result.push(entry);
-    if (entry.id !== undefined) allIds.add(entry.id);
   });
 
-  // Hex entries second
   Array.from(hexMap.values()).forEach(entry => {
     result.push(entry);
-    if (entry.id !== undefined) allIds.add(entry.id);
   });
 
-  // Collect IDs of entries that were coalesced away (not in the final set)
   result.sort((a, b) => a.timestamp - b.timestamp);
 
   return result;
@@ -338,6 +332,14 @@ export class SyncEngine {
         const updatedCampaign = { ...conflict.localCampaign, version: result.newVersion };
         await cacheCampaign(updatedCampaign, result.newVersion ?? conflict.remoteVersion + 1);
         await updateBaseSnapshot(conflict.campaignId, updatedCampaign);
+        // Clear stale queue entries for this campaign
+        const entries = await getSyncQueue(conflict.campaignId);
+        const ids = entries.map(e => e.id).filter((id): id is number => id !== undefined);
+        if (ids.length > 0) {
+          await clearSyncQueue(ids);
+        }
+        // Notify CampaignContext to update in-memory version
+        this.notifyReload(updatedCampaign);
       } else if (resolution.strategy === 'keep-remote') {
         // Discard local changes — replace with remote
         const remote = conflict.remoteCampaign;
@@ -541,11 +543,13 @@ export class SyncEngine {
    */
   private async handleVersionConflict(
     localCampaign: Campaign,
-    serverVersion: number
+    _serverVersion: number
   ): Promise<void> {
     this.queuePaused = true;
 
     try {
+      // Fetch the latest remote state (may be newer than _serverVersion if
+      // another write landed between the RPC rejection and this fetch)
       const { campaign: remoteCampaign } = await loadCloudCampaign(
         this.client,
         localCampaign.id
@@ -555,10 +559,8 @@ export class SyncEngine {
         return;
       }
 
+      // computeCampaignConflict already populates versions from the campaigns
       const conflict = computeCampaignConflict(localCampaign, remoteCampaign);
-      // Override versions from the actual server state
-      conflict.remoteVersion = serverVersion;
-      conflict.localVersion = localCampaign.version ?? 0;
 
       this.setPendingConflict(conflict);
       this.setStatus('conflict');

--- a/src/services/syncEngine.ts
+++ b/src/services/syncEngine.ts
@@ -1,25 +1,95 @@
 // syncEngine — Coordinates between local IndexedDB cache and Supabase.
 // Writes to cache immediately for instant local feedback, then queues
 // changes for remote sync. Replays the offline queue when connectivity
-// is restored.
+// is restored. Detects version conflicts via the versioned RPC and
+// exposes conflict state for the resolution UI.
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Campaign, Hex } from '../types';
+import type { CampaignConflict, ConflictResolution } from '../types/Sync';
 import {
   cacheCampaign,
   cacheHex,
   addToSyncQueue,
   getSyncQueue,
   clearSyncQueue,
+  getSyncQueueCount,
+  updateBaseSnapshot,
   type SyncQueueEntry,
 } from './localCache';
-import { saveCloudCampaign, upsertHex } from './cloudStorage';
+import { saveCloudCampaignVersioned, loadCloudCampaign, upsertHex } from './cloudStorage';
+import type { VersionedSaveResult } from './cloudStorage';
 import { connectionManager } from './connectionManager';
+import { computeCampaignConflict } from './conflictResolver';
 
 // ============ TYPES ============
 
 export type SyncStatus = 'synced' | 'syncing' | 'offline' | 'conflict' | 'error';
 type SyncStatusListener = (status: SyncStatus) => void;
+type ConflictListener = (conflict: CampaignConflict | null) => void;
+type CampaignReloadListener = (campaign: Campaign) => void;
+
+const MAX_RETRIES = 3;
+
+// ============ QUEUE COALESCING ============
+
+/**
+ * Coalesce queue entries: keep only the latest entry per campaign (campaign type)
+ * and per campaign:hexKey (hex type). This avoids pushing N intermediate states
+ * when the user made N edits offline.
+ */
+function coalesceQueue(entries: SyncQueueEntry[]): SyncQueueEntry[] {
+  // Track the latest entry per key
+  const campaignMap = new Map<string, SyncQueueEntry>();
+  const hexMap = new Map<string, SyncQueueEntry>();
+
+  for (const entry of entries) {
+    if (entry.type === 'campaign') {
+      // Keep the latest campaign-level entry per campaignId
+      const existing = campaignMap.get(entry.campaignId);
+      if (!existing || entry.timestamp > existing.timestamp) {
+        campaignMap.set(entry.campaignId, entry);
+      }
+    } else if (entry.type === 'hex' && entry.hexKey) {
+      const key = `${entry.campaignId}:${entry.hexKey}`;
+      const existing = hexMap.get(key);
+      if (!existing || entry.timestamp > existing.timestamp) {
+        hexMap.set(key, entry);
+      }
+    }
+  }
+
+  // Rebuild: campaign entries first, then hex entries, preserving campaign order
+  const result: SyncQueueEntry[] = [];
+  const allIds = new Set<number>();
+
+  // Campaign entries first
+  Array.from(campaignMap.values()).forEach(entry => {
+    result.push(entry);
+    if (entry.id !== undefined) allIds.add(entry.id);
+  });
+
+  // Hex entries second
+  Array.from(hexMap.values()).forEach(entry => {
+    result.push(entry);
+    if (entry.id !== undefined) allIds.add(entry.id);
+  });
+
+  // Collect IDs of entries that were coalesced away (not in the final set)
+  result.sort((a, b) => a.timestamp - b.timestamp);
+
+  return result;
+}
+
+/**
+ * Get IDs of entries that were removed during coalescing (for cleanup).
+ */
+function getCoalescedIds(original: SyncQueueEntry[], coalesced: SyncQueueEntry[]): number[] {
+  const keptIds = new Set(coalesced.map(e => e.id).filter((id): id is number => id !== undefined));
+  return original
+    .map(e => e.id)
+    .filter((id): id is number => id !== undefined && !keptIds.has(id));
+}
 
 // ============ SYNC ENGINE ============
 
@@ -28,8 +98,12 @@ export class SyncEngine {
   private userId: string;
   private status: SyncStatus = 'synced';
   private statusListeners: Set<SyncStatusListener> = new Set();
+  private conflictListeners: Set<ConflictListener> = new Set();
+  private reloadListeners: Set<CampaignReloadListener> = new Set();
   private syncTimer: ReturnType<typeof setTimeout> | null = null;
   private connectionCleanup: (() => void) | null = null;
+  private pendingConflict: CampaignConflict | null = null;
+  private queuePaused: boolean = false;
 
   constructor(client: SupabaseClient, userId: string) {
     this.client = client;
@@ -88,7 +162,7 @@ export class SyncEngine {
     // Write to local cache immediately
     await cacheCampaign(campaign, version);
 
-    if (connectionManager.online) {
+    if (connectionManager.online && !this.queuePaused) {
       // Debounce remote push
       if (this.syncTimer !== null) {
         clearTimeout(this.syncTimer);
@@ -97,41 +171,29 @@ export class SyncEngine {
         this.syncTimer = null;
         this.setStatus('syncing');
         try {
-          const { error } = await saveCloudCampaign(this.client, campaign, this.userId);
-          if (error) {
-            // Remote save failed — queue for retry
-            await addToSyncQueue({
-              campaignId: campaign.id,
-              type: 'campaign',
-              data: campaign,
-              version,
-              timestamp: Date.now(),
-            });
+          const result = await this.pushCampaignToRemote(campaign);
+          if (result === 'conflict') {
+            // Conflict handling already triggered in pushCampaignToRemote
+            return;
+          } else if (result === 'error') {
+            await this.queueCampaign(campaign, version);
             this.setStatus('error');
           } else {
+            // Success — update base snapshot
+            await updateBaseSnapshot(campaign.id, { ...campaign, version: result });
             this.setStatus('synced');
           }
         } catch {
-          await addToSyncQueue({
-            campaignId: campaign.id,
-            type: 'campaign',
-            data: campaign,
-            version,
-            timestamp: Date.now(),
-          });
+          await this.queueCampaign(campaign, version);
           this.setStatus('error');
         }
       }, debounceMs);
     } else {
-      // Offline — queue for later
-      await addToSyncQueue({
-        campaignId: campaign.id,
-        type: 'campaign',
-        data: campaign,
-        version,
-        timestamp: Date.now(),
-      });
-      this.setStatus('offline');
+      // Offline or paused — queue for later
+      await this.queueCampaign(campaign, version);
+      if (!connectionManager.online) {
+        this.setStatus('offline');
+      }
     }
   }
 
@@ -145,7 +207,7 @@ export class SyncEngine {
     // Write to local cache immediately
     await cacheHex(campaignId, hexKey, hex, version);
 
-    if (connectionManager.online) {
+    if (connectionManager.online && !this.queuePaused) {
       this.setStatus('syncing');
       try {
         const { error } = await upsertHex(this.client, campaignId, hexKey, hex, version);
@@ -182,58 +244,159 @@ export class SyncEngine {
         version,
         timestamp: Date.now(),
       });
-      this.setStatus('offline');
+      if (!connectionManager.online) {
+        this.setStatus('offline');
+      }
     }
   }
 
   /**
-   * Replay the offline sync queue, pushing entries to the server in order.
-   * On conflict (version mismatch), sets status to 'conflict' and stops.
+   * Replay the offline sync queue with coalescing and retry logic.
+   * On conflict (version mismatch), pauses and triggers conflict resolution.
    */
   async replayQueue(): Promise<void> {
-    const entries = await getSyncQueue();
-    if (entries.length === 0) {
+    if (this.queuePaused) return;
+
+    const allEntries = await getSyncQueue();
+    if (allEntries.length === 0) {
       this.setStatus('synced');
       return;
     }
 
     this.setStatus('syncing');
+
+    // Coalesce: keep only the latest entry per entity
+    const coalesced = coalesceQueue(allEntries);
+
+    // Clean up entries that were coalesced away
+    const removedIds = getCoalescedIds(allEntries, coalesced);
+    if (removedIds.length > 0) {
+      await clearSyncQueue(removedIds);
+    }
+
     const processedIds: number[] = [];
 
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i];
+    for (let i = 0; i < coalesced.length; i++) {
+      const entry = coalesced[i];
       if (!connectionManager.online) {
-        // Lost connection mid-replay
         this.setStatus('offline');
         break;
       }
+      if (this.queuePaused) break;
 
-      const success = await this.pushToRemote(entry);
-      if (success) {
+      const result = await this.pushEntryToRemote(entry);
+      if (result === 'success') {
         if (entry.id !== undefined) {
           processedIds.push(entry.id);
         }
-      } else {
-        // Stop processing on failure — remaining entries stay queued
+      } else if (result === 'conflict') {
+        // Conflict detected — pause and wait for resolution
         break;
+      } else {
+        // Error — skip after retries exhausted (handled in pushEntryToRemote)
+        // Continue to next entry
+        if (entry.id !== undefined) {
+          processedIds.push(entry.id); // Remove failed entry after max retries
+        }
       }
     }
 
-    // Clear successfully processed entries
+    // Clear processed entries
     if (processedIds.length > 0) {
       await clearSyncQueue(processedIds);
     }
 
-    // Update status based on outcome
+    // Update status
     if (this.status !== 'conflict' && this.status !== 'offline') {
-      const remaining = await getSyncQueue();
-      this.setStatus(remaining.length === 0 ? 'synced' : 'error');
+      const remaining = await getSyncQueueCount();
+      this.setStatus(remaining === 0 ? 'synced' : 'error');
+    }
+  }
+
+  /**
+   * Resolve a pending conflict with the user's chosen strategy.
+   */
+  async resolveConflict(resolution: ConflictResolution): Promise<void> {
+    const conflict = this.pendingConflict;
+    if (!conflict) return;
+
+    this.setStatus('syncing');
+
+    try {
+      if (resolution.strategy === 'keep-local') {
+        // Force-push local version using the server's version as expected
+        const result = await saveCloudCampaignVersioned(
+          this.client,
+          conflict.localCampaign,
+          this.userId,
+          conflict.remoteVersion
+        );
+        if (result.error || result.conflict) {
+          this.setStatus('error');
+          return;
+        }
+        const updatedCampaign = { ...conflict.localCampaign, version: result.newVersion };
+        await cacheCampaign(updatedCampaign, result.newVersion ?? conflict.remoteVersion + 1);
+        await updateBaseSnapshot(conflict.campaignId, updatedCampaign);
+      } else if (resolution.strategy === 'keep-remote') {
+        // Discard local changes — replace with remote
+        const remote = conflict.remoteCampaign;
+        await cacheCampaign(remote, conflict.remoteVersion);
+        await updateBaseSnapshot(conflict.campaignId, remote);
+        // Clear all queue entries for this campaign
+        const entries = await getSyncQueue(conflict.campaignId);
+        const ids = entries.map(e => e.id).filter((id): id is number => id !== undefined);
+        if (ids.length > 0) {
+          await clearSyncQueue(ids);
+        }
+        // Notify CampaignContext to reload with remote data
+        this.notifyReload(remote);
+      } else if (resolution.strategy === 'manual') {
+        // Push the user's merged campaign
+        const merged = resolution.resolvedCampaign;
+        const result = await saveCloudCampaignVersioned(
+          this.client,
+          merged,
+          this.userId,
+          conflict.remoteVersion
+        );
+        if (result.error || result.conflict) {
+          this.setStatus('error');
+          return;
+        }
+        const updatedCampaign = { ...merged, version: result.newVersion };
+        await cacheCampaign(updatedCampaign, result.newVersion ?? conflict.remoteVersion + 1);
+        await updateBaseSnapshot(conflict.campaignId, updatedCampaign);
+        this.notifyReload(updatedCampaign);
+      }
+
+      // Clear conflict state and resume
+      this.setPendingConflict(null);
+      this.queuePaused = false;
+      this.setStatus('synced');
+
+      // Resume queue replay for any remaining entries
+      this.replayQueue().catch(() => {
+        this.setStatus('error');
+      });
+    } catch {
+      this.setStatus('error');
     }
   }
 
   /** Get current sync status. */
   getStatus(): SyncStatus {
     return this.status;
+  }
+
+  /** Get the current pending conflict, if any. */
+  getPendingConflict(): CampaignConflict | null {
+    return this.pendingConflict;
+  }
+
+  /** Get the number of pending queue entries. */
+  async getQueueCount(): Promise<number> {
+    return getSyncQueueCount();
   }
 
   /**
@@ -247,56 +410,161 @@ export class SyncEngine {
     };
   }
 
-  private setStatus(status: SyncStatus): void {
-    if (this.status === status) return;
-    this.status = status;
-    // Use Array.from().forEach() instead of for...of (ES3 compat for electron/)
-    Array.from(this.statusListeners).forEach(listener => listener(status));
+  /**
+   * Subscribe to conflict changes.
+   * Returns an unsubscribe function.
+   */
+  onConflictChange(listener: ConflictListener): () => void {
+    this.conflictListeners.add(listener);
+    return () => {
+      this.conflictListeners.delete(listener);
+    };
   }
 
   /**
-   * Push a single queued entry to the remote server.
-   * Returns true on success, false on failure.
-   * Sets status to 'conflict' if a version conflict is detected.
+   * Subscribe to campaign reload events (triggered by keep-remote resolution).
+   * Returns an unsubscribe function.
    */
-  private async pushToRemote(entry: SyncQueueEntry): Promise<boolean> {
+  onCampaignReload(listener: CampaignReloadListener): () => void {
+    this.reloadListeners.add(listener);
+    return () => {
+      this.reloadListeners.delete(listener);
+    };
+  }
+
+  // ============ PRIVATE ============
+
+  private setStatus(status: SyncStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    Array.from(this.statusListeners).forEach(listener => listener(status));
+  }
+
+  private setPendingConflict(conflict: CampaignConflict | null): void {
+    this.pendingConflict = conflict;
+    Array.from(this.conflictListeners).forEach(listener => listener(conflict));
+  }
+
+  private notifyReload(campaign: Campaign): void {
+    Array.from(this.reloadListeners).forEach(listener => listener(campaign));
+  }
+
+  private async queueCampaign(campaign: Campaign, version: number): Promise<void> {
+    await addToSyncQueue({
+      campaignId: campaign.id,
+      type: 'campaign',
+      data: campaign,
+      version,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Push a campaign to remote with version checking.
+   * Returns the new version number on success, 'conflict' if version mismatch,
+   * or 'error' on failure.
+   */
+  private async pushCampaignToRemote(
+    campaign: Campaign
+  ): Promise<number | 'conflict' | 'error'> {
+    const expectedVersion = campaign.version ?? 0;
+
+    let result: VersionedSaveResult;
     try {
-      if (entry.type === 'campaign') {
-        const campaign = entry.data as Campaign;
-        const { error } = await saveCloudCampaign(this.client, campaign, this.userId);
-        if (error) {
-          // Check for version conflict indicators
-          if (error.includes('conflict') || error.includes('version')) {
-            this.setStatus('conflict');
-          } else {
-            this.setStatus('error');
+      result = await saveCloudCampaignVersioned(
+        this.client,
+        campaign,
+        this.userId,
+        expectedVersion
+      );
+    } catch {
+      return 'error';
+    }
+
+    if (result.error) {
+      return 'error';
+    }
+
+    if (result.conflict) {
+      // Version mismatch — fetch remote and compute conflict
+      await this.handleVersionConflict(campaign, result.serverVersion ?? 0);
+      return 'conflict';
+    }
+
+    return result.newVersion ?? expectedVersion + 1;
+  }
+
+  /**
+   * Push a single queued entry to the remote server with retry logic.
+   * Returns 'success', 'conflict', or 'error'.
+   */
+  private async pushEntryToRemote(
+    entry: SyncQueueEntry
+  ): Promise<'success' | 'conflict' | 'error'> {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        if (entry.type === 'campaign') {
+          const campaign = entry.data as Campaign;
+          const result = await this.pushCampaignToRemote(campaign);
+          if (result === 'conflict') return 'conflict';
+          if (typeof result === 'number') {
+            await updateBaseSnapshot(campaign.id, { ...campaign, version: result });
+            return 'success';
           }
-          return false;
+          // result === 'error' — retry
+        } else if (entry.type === 'hex' && entry.hexKey) {
+          const hex = entry.data as Hex;
+          const { error } = await upsertHex(
+            this.client,
+            entry.campaignId,
+            entry.hexKey,
+            hex,
+            entry.version
+          );
+          if (!error) return 'success';
+          // Has error — retry
+        } else {
+          return 'error'; // Unknown entry type
         }
-        return true;
-      } else if (entry.type === 'hex' && entry.hexKey) {
-        const hex = entry.data as Hex;
-        const { error } = await upsertHex(
-          this.client,
-          entry.campaignId,
-          entry.hexKey,
-          hex,
-          entry.version
-        );
-        if (error) {
-          if (error.includes('conflict') || error.includes('version')) {
-            this.setStatus('conflict');
-          } else {
-            this.setStatus('error');
-          }
-          return false;
-        }
-        return true;
+      } catch {
+        // Network error — retry
       }
-      return false;
+    }
+
+    // Exhausted retries
+    return 'error';
+  }
+
+  /**
+   * Handle a version conflict: fetch remote campaign, compute diff,
+   * pause queue, and notify listeners.
+   */
+  private async handleVersionConflict(
+    localCampaign: Campaign,
+    serverVersion: number
+  ): Promise<void> {
+    this.queuePaused = true;
+
+    try {
+      const { campaign: remoteCampaign } = await loadCloudCampaign(
+        this.client,
+        localCampaign.id
+      );
+      if (!remoteCampaign) {
+        this.setStatus('error');
+        return;
+      }
+
+      const conflict = computeCampaignConflict(localCampaign, remoteCampaign);
+      // Override versions from the actual server state
+      conflict.remoteVersion = serverVersion;
+      conflict.localVersion = localCampaign.version ?? 0;
+
+      this.setPendingConflict(conflict);
+      this.setStatus('conflict');
     } catch {
       this.setStatus('error');
-      return false;
+      this.queuePaused = false;
     }
   }
 }

--- a/src/stores/CampaignContext.tsx
+++ b/src/stores/CampaignContext.tsx
@@ -248,7 +248,7 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       return updateWithHistory(state, {
         timeWeather: {
           ...state.campaign.timeWeather,
-          time: action.time
+          currentTime: action.time
         }
       });
     }

--- a/src/stores/CampaignContext.tsx
+++ b/src/stores/CampaignContext.tsx
@@ -8,6 +8,7 @@ import { getTemplateById } from '../data/campaignTemplates';
 import { applyCustomizations } from '../services/templateService';
 import { migrateCampaign } from '../types/Campaign';
 import type { PersistenceAdapter } from '../services/persistence';
+import type { SyncEngine } from '../services/syncEngine';
 import { createMarker, createCustomMarkerType, DEFAULT_MARKER_TYPES } from '../types/Markers';
 import {
   TimeWeatherState,
@@ -101,6 +102,27 @@ const initialState: CampaignState = {
   future: []
 };
 
+// Helper to create a new state with updated campaign and history tracking
+function updateWithHistory(state: CampaignState, updates: Partial<Campaign>): CampaignState {
+  if (!state.campaign) return state;
+
+  const updatedCampaign = {
+    ...state.campaign,
+    ...updates,
+    modifiedAt: new Date().toISOString()
+  };
+  const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
+
+  return {
+    ...state,
+    campaign: updatedCampaign,
+    saveStatus: 'unsaved',
+    hasUnsavedChanges: true,
+    past: newPast,
+    future: []  // Clear redo stack on new action
+  };
+}
+
 // Reducer
 function campaignReducer(state: CampaignState, action: CampaignAction): CampaignState {
   switch (action.type) {
@@ -119,42 +141,15 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
     case 'UPDATE_HEX': {
       if (!state.campaign) return state;
       const key = coordinateKey(action.hex.coordinate);
-      // Save current state to history before mutation
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [key]: action.hex
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []  // Clear redo stack on new action
+      const newHexes = {
+        ...state.campaign.hexes,
+        [key]: action.hex
       };
+      return updateWithHistory(state, { hexes: newHexes });
     }
 
-    case 'UPDATE_CAMPAIGN': {
-      if (!state.campaign) return state;
-      // Save current state to history before mutation
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          ...action.updates,
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []  // Clear redo stack on new action
-      };
-    }
+    case 'UPDATE_CAMPAIGN':
+      return updateWithHistory(state, action.updates);
 
     case 'MARK_SAVED':
       return {
@@ -235,168 +230,86 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
     case 'INIT_TIME_WEATHER': {
       if (!state.campaign) return state;
       if (state.campaign.timeWeather) return state; // Already initialized
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: createDefaultTimeWeather(),
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, { timeWeather: createDefaultTimeWeather() });
     }
 
     case 'SET_CALENDAR': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            calendar: action.calendar
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          calendar: action.calendar
+        }
+      });
     }
 
     case 'SET_TIME': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            currentTime: action.time
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          time: action.time
+        }
+      });
     }
 
     case 'ADVANCE_TIME': {
       if (!state.campaign?.timeWeather) return state;
       const tw = state.campaign.timeWeather;
       const newTime = advanceTime(tw.calendar, tw.currentTime, action.hours, action.minutes || 0);
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...tw,
-            currentTime: newTime
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...tw,
+          currentTime: newTime
+        }
+      });
     }
 
     case 'SET_GLOBAL_WEATHER': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            globalWeather: action.weather
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          globalWeather: action.weather
+        }
+      });
     }
 
     case 'SET_ZONE_WEATHER': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            zoneWeathers: {
-              ...state.campaign.timeWeather.zoneWeathers,
-              [action.zoneId]: action.weather
-            }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          zoneWeathers: {
+            ...state.campaign.timeWeather.zoneWeathers,
+            [action.zoneId]: action.weather
+          }
+        }
+      });
     }
 
     case 'SET_HEX_WEATHER': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            hexWeatherOverrides: {
-              ...state.campaign.timeWeather.hexWeatherOverrides,
-              [action.hexKey]: action.weather
-            }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          hexWeatherOverrides: {
+            ...state.campaign.timeWeather.hexWeatherOverrides,
+            [action.hexKey]: action.weather
+          }
+        }
+      });
     }
 
     case 'CLEAR_HEX_WEATHER': {
       if (!state.campaign?.timeWeather) return state;
       const { [action.hexKey]: _, ...remainingOverrides } = state.campaign.timeWeather.hexWeatherOverrides;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            hexWeatherOverrides: remainingOverrides
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          hexWeatherOverrides: remainingOverrides
+        }
+      });
     }
 
     case 'GENERATE_WEATHER': {
@@ -405,22 +318,12 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       const season = getCurrentSeason(tw.calendar, tw.currentTime.month);
       const terrain = action.terrain || 'Plains';
       const newWeather = generateWeather(terrain, season);
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...tw,
-            globalWeather: newWeather
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...tw,
+          globalWeather: newWeather
+        }
+      });
     }
 
     case 'LOG_WEATHER': {
@@ -443,22 +346,12 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
 
     case 'UPDATE_WEATHER_SETTINGS': {
       if (!state.campaign?.timeWeather) return state;
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          timeWeather: {
-            ...state.campaign.timeWeather,
-            ...action.settings
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        timeWeather: {
+          ...state.campaign.timeWeather,
+          ...action.settings
+        }
+      });
     }
 
     // ============ MARKER ACTIONS ============
@@ -468,22 +361,12 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       const key = coordinateKey(action.coord);
       const hex = state.campaign.hexes[key] || createHex(action.coord);
       const markers = [...(hex.markers || []), action.marker];
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [key]: { ...hex, markers }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        hexes: {
+          ...state.campaign.hexes,
+          [key]: { ...hex, markers }
+        }
+      });
     }
 
     case 'REMOVE_MARKER': {
@@ -492,22 +375,12 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       const hex = state.campaign.hexes[key];
       if (!hex || !hex.markers) return state;
       const markers = hex.markers.filter(m => m.id !== action.markerId);
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [key]: { ...hex, markers }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        hexes: {
+          ...state.campaign.hexes,
+          [key]: { ...hex, markers }
+        }
+      });
     }
 
     case 'MOVE_MARKER': {
@@ -527,23 +400,13 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       const toHex = state.campaign.hexes[toKey] || createHex(action.toCoord);
       const toMarkers = [...(toHex.markers || []), movedMarker];
 
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [fromKey]: { ...fromHex, markers: fromMarkers },
-            [toKey]: { ...toHex, markers: toMarkers }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        hexes: {
+          ...state.campaign.hexes,
+          [fromKey]: { ...fromHex, markers: fromMarkers },
+          [toKey]: { ...toHex, markers: toMarkers }
+        }
+      });
     }
 
     case 'MOVE_MARKER_TO_POSITION': {
@@ -559,22 +422,12 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
           : m
       );
 
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [key]: { ...hex, markers }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        hexes: {
+          ...state.campaign.hexes,
+          [key]: { ...hex, markers }
+        }
+      });
     }
 
     case 'UPDATE_MARKER': {
@@ -585,59 +438,25 @@ function campaignReducer(state: CampaignState, action: CampaignAction): Campaign
       const markers = hex.markers.map(m =>
         m.id === action.marker.id ? action.marker : m
       );
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          hexes: {
-            ...state.campaign.hexes,
-            [key]: { ...hex, markers }
-          },
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, {
+        hexes: {
+          ...state.campaign.hexes,
+          [key]: { ...hex, markers }
+        }
+      });
     }
 
     case 'ADD_CUSTOM_MARKER_TYPE': {
       if (!state.campaign) return state;
       const markerTypes = [...(state.campaign.markerTypes || DEFAULT_MARKER_TYPES), action.markerType];
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          markerTypes,
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, { markerTypes });
     }
 
     case 'REMOVE_MARKER_TYPE': {
       if (!state.campaign) return state;
       const markerTypes = (state.campaign.markerTypes || DEFAULT_MARKER_TYPES)
         .filter(t => t.id !== action.markerTypeId);
-      const newPast = [...state.past, state.campaign].slice(-MAX_HISTORY_SIZE);
-      return {
-        ...state,
-        campaign: {
-          ...state.campaign,
-          markerTypes,
-          modifiedAt: new Date().toISOString()
-        },
-        saveStatus: 'unsaved',
-        hasUnsavedChanges: true,
-        past: newPast,
-        future: []
-      };
+      return updateWithHistory(state, { markerTypes });
     }
 
     default:
@@ -753,11 +572,13 @@ interface CampaignContextValue {
 const CampaignContext = createContext<CampaignContextValue | null>(null);
 
 // Provider component
-export function CampaignProvider({ children, adapter }: { children: React.ReactNode; adapter: PersistenceAdapter }) {
+export function CampaignProvider({ children, adapter, syncEngine }: { children: React.ReactNode; adapter: PersistenceAdapter; syncEngine?: SyncEngine | null }) {
   const [state, dispatch] = useReducer(campaignReducer, initialState);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Autosave effect (2 second debounce)
+  // When syncEngine is available, routes through it for version-checked saves.
+  // Otherwise falls back to the persistence adapter directly.
   useEffect(() => {
     if (state.hasUnsavedChanges && state.campaign) {
       // Clear existing timeout
@@ -765,24 +586,41 @@ export function CampaignProvider({ children, adapter }: { children: React.ReactN
         clearTimeout(saveTimeoutRef.current);
       }
 
-      // Set new timeout for autosave
-      saveTimeoutRef.current = setTimeout(async () => {
-        if (state.campaign) {
-          dispatch({ type: 'MARK_SAVING' });
-          try {
-            const result = await adapter.save(
-              state.campaign,
-              state.currentFilePath ?? undefined
-            );
-            if (result.success) {
-              dispatch({ type: 'MARK_SAVED', filePath: result.path });
+      if (syncEngine) {
+        // Route through SyncEngine — it handles its own debounce, cache, and version checking
+        saveTimeoutRef.current = setTimeout(async () => {
+          if (state.campaign) {
+            dispatch({ type: 'MARK_SAVING' });
+            try {
+              await syncEngine.saveCampaign(state.campaign);
+              dispatch({ type: 'MARK_SAVED', filePath: state.currentFilePath ?? undefined });
+            } catch (error) {
+              console.error('Autosave via SyncEngine failed:', error);
+              dispatch({ type: 'SAVE_FAILED' });
             }
-          } catch (error) {
-            console.error('Autosave failed:', error);
-            dispatch({ type: 'SAVE_FAILED' });
           }
-        }
-      }, 2000);
+        }, 100); // Short delay — SyncEngine has its own 2s debounce for remote push
+      } else {
+        // Direct adapter save (local-only mode)
+        saveTimeoutRef.current = setTimeout(async () => {
+          if (state.campaign) {
+            dispatch({ type: 'MARK_SAVING' });
+            try {
+              const result = await adapter.save(
+                state.campaign,
+                state.currentFilePath ?? undefined,
+                { compact: true }
+              );
+              if (result.success) {
+                dispatch({ type: 'MARK_SAVED', filePath: result.path });
+              }
+            } catch (error) {
+              console.error('Autosave failed:', error);
+              dispatch({ type: 'SAVE_FAILED' });
+            }
+          }
+        }, 2000);
+      }
     }
 
     return () => {
@@ -790,7 +628,19 @@ export function CampaignProvider({ children, adapter }: { children: React.ReactN
         clearTimeout(saveTimeoutRef.current);
       }
     };
-  }, [state.hasUnsavedChanges, state.campaign, state.currentFilePath, adapter]);
+  }, [state.hasUnsavedChanges, state.campaign, state.currentFilePath, adapter, syncEngine]);
+
+  // Listen for SyncEngine reload events (keep-remote conflict resolution)
+  useEffect(() => {
+    if (!syncEngine) return;
+    return syncEngine.onCampaignReload((campaign) => {
+      dispatch({
+        type: 'SET_CAMPAIGN',
+        campaign,
+        filePath: state.currentFilePath ?? undefined,
+      });
+    });
+  }, [syncEngine, state.currentFilePath]);
 
   // Create new campaign
   const newCampaign = useCallback((
@@ -849,14 +699,15 @@ export function CampaignProvider({ children, adapter }: { children: React.ReactN
   }, [adapter]);
 
   // Save campaign
-  const saveCampaign = useCallback(async () => {
+  const saveCampaign = useCallback(async (options?: { compact?: boolean }) => {
     if (!state.campaign) return;
 
     dispatch({ type: 'MARK_SAVING' });
     try {
       const result = await adapter.save(
         state.campaign,
-        state.currentFilePath ?? undefined
+        state.currentFilePath ?? undefined,
+        options
       );
       if (result.success) {
         dispatch({ type: 'MARK_SAVED', filePath: result.path });
@@ -1282,7 +1133,7 @@ export function CampaignProvider({ children, adapter }: { children: React.ReactN
     [adapter]
   );
 
-  const value: CampaignContextValue = {
+  const value: CampaignContextValue = useMemo(() => ({
     state,
     newCampaign,
     loadCampaign,
@@ -1380,7 +1231,72 @@ export function CampaignProvider({ children, adapter }: { children: React.ReactN
     updateTerrainType,
     deleteTerrainType,
     renameTerrainType
-  };
+  }), [
+    state,
+    newCampaign,
+    loadCampaign,
+    saveCampaign,
+    saveAs,
+    closeCampaign,
+    getHex,
+    getOrCreateHex,
+    updateHex,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    initTimeWeather,
+    setCalendar,
+    setTime,
+    advanceTimeBy,
+    setGlobalWeather,
+    setHexWeather,
+    clearHexWeather,
+    generateNewWeather,
+    updateWeatherSettings,
+    timeWeather,
+    currentSeason,
+    currentTimeOfDay,
+    formattedTime,
+    formattedDate,
+    weatherSummary,
+    getWeatherForHex,
+    getWeatherEffectsForHex,
+    addMarker,
+    addMarkerAtPosition,
+    removeMarker,
+    moveMarker,
+    moveMarkerToPosition,
+    updateMarker,
+    addCustomMarkerType,
+    removeMarkerType,
+    markerTypes,
+    listCampaigns,
+    deleteCampaignFile,
+    updateCampaignData,
+    toggleBookmark,
+    isBookmarked,
+    bookmarkedHexes,
+    encounterTemplates,
+    allNpcs,
+    factions,
+    sessions,
+    sessionLog,
+    quests,
+    storyArcs,
+    regions,
+    addRegion,
+    updateRegion,
+    deleteRegion,
+    addHexToRegion,
+    removeHexFromRegion,
+    getRegionForHexFn,
+    terrainTypes,
+    addTerrainType,
+    updateTerrainType,
+    deleteTerrainType,
+    renameTerrainType
+  ]);
 
   return (
     <CampaignContext.Provider value={value}>

--- a/src/stores/SyncContext.tsx
+++ b/src/stores/SyncContext.tsx
@@ -52,23 +52,27 @@ export function SyncProvider({ engine, children }: SyncProviderProps) {
   useEffect(() => {
     if (!engine) return;
 
+    let mounted = true;
+    const safeSetQueueCount = (count: number) => { if (mounted) setQueueCount(count); };
+
     setSyncStatus(engine.getStatus());
     setPendingConflict(engine.getPendingConflict());
 
     const unsubStatus = engine.onStatusChange((status) => {
-      setSyncStatus(status);
+      if (mounted) setSyncStatus(status);
       // Refresh queue count on status change
-      engine.getQueueCount().then(setQueueCount).catch(() => {});
+      engine.getQueueCount().then(safeSetQueueCount).catch(() => {});
     });
 
     const unsubConflict = engine.onConflictChange((conflict) => {
-      setPendingConflict(conflict);
+      if (mounted) setPendingConflict(conflict);
     });
 
     // Initial queue count
-    engine.getQueueCount().then(setQueueCount).catch(() => {});
+    engine.getQueueCount().then(safeSetQueueCount).catch(() => {});
 
     return () => {
+      mounted = false;
       unsubStatus();
       unsubConflict();
     };
@@ -77,9 +81,12 @@ export function SyncProvider({ engine, children }: SyncProviderProps) {
   const resolveConflict = useCallback(
     async (resolution: ConflictResolution) => {
       if (!engine) return;
-      await engine.resolveConflict(resolution);
-      const count = await engine.getQueueCount();
-      setQueueCount(count);
+      try {
+        await engine.resolveConflict(resolution);
+      } finally {
+        // Always refresh queue count, even on error
+        engine.getQueueCount().then(setQueueCount).catch(() => {});
+      }
     },
     [engine]
   );

--- a/src/stores/SyncContext.tsx
+++ b/src/stores/SyncContext.tsx
@@ -1,0 +1,98 @@
+// SyncContext — React context wrapping SyncEngine for UI consumption.
+// Exposes sync status, pending conflicts, queue count, and resolution actions.
+// Falls back to a no-op context when cloud sync is disabled.
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import type { SyncEngine, SyncStatus } from '../services/syncEngine';
+import type { CampaignConflict, ConflictResolution } from '../types/Sync';
+
+interface SyncContextValue {
+  syncStatus: SyncStatus;
+  pendingConflict: CampaignConflict | null;
+  queueCount: number;
+  resolveConflict: (resolution: ConflictResolution) => Promise<void>;
+}
+
+const defaultValue: SyncContextValue = {
+  syncStatus: 'synced',
+  pendingConflict: null,
+  queueCount: 0,
+  resolveConflict: async () => {},
+};
+
+const SyncContext = createContext<SyncContextValue>(defaultValue);
+
+export function useSyncContext(): SyncContextValue {
+  return useContext(SyncContext);
+}
+
+interface SyncProviderProps {
+  engine: SyncEngine | null;
+  children: ReactNode;
+}
+
+export function SyncProvider({ engine, children }: SyncProviderProps) {
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>(
+    engine?.getStatus() ?? 'synced'
+  );
+  const [pendingConflict, setPendingConflict] = useState<CampaignConflict | null>(
+    engine?.getPendingConflict() ?? null
+  );
+  const [queueCount, setQueueCount] = useState(0);
+
+  // Subscribe to engine status and conflict changes
+  useEffect(() => {
+    if (!engine) return;
+
+    setSyncStatus(engine.getStatus());
+    setPendingConflict(engine.getPendingConflict());
+
+    const unsubStatus = engine.onStatusChange((status) => {
+      setSyncStatus(status);
+      // Refresh queue count on status change
+      engine.getQueueCount().then(setQueueCount).catch(() => {});
+    });
+
+    const unsubConflict = engine.onConflictChange((conflict) => {
+      setPendingConflict(conflict);
+    });
+
+    // Initial queue count
+    engine.getQueueCount().then(setQueueCount).catch(() => {});
+
+    return () => {
+      unsubStatus();
+      unsubConflict();
+    };
+  }, [engine]);
+
+  const resolveConflict = useCallback(
+    async (resolution: ConflictResolution) => {
+      if (!engine) return;
+      await engine.resolveConflict(resolution);
+      const count = await engine.getQueueCount();
+      setQueueCount(count);
+    },
+    [engine]
+  );
+
+  const value = useMemo(
+    () => ({
+      syncStatus,
+      pendingConflict,
+      queueCount,
+      resolveConflict,
+    }),
+    [syncStatus, pendingConflict, queueCount, resolveConflict]
+  );
+
+  return <SyncContext.Provider value={value}>{children}</SyncContext.Provider>;
+}

--- a/src/styles/auth.css
+++ b/src/styles/auth.css
@@ -122,6 +122,12 @@
 
 .connection-dot--syncing {
   background: var(--warning-color);
+  animation: pulse-dot 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 .connection-dot--offline {
@@ -134,6 +140,149 @@
 
 .connection-dot--error {
   background: var(--danger-color);
+}
+
+/* Conflict Resolution Modal */
+
+.conflict-resolution-modal {
+  max-width: 560px;
+  max-height: 80vh;
+}
+
+.conflict-resolution-modal .modal-body {
+  overflow-y: auto;
+  max-height: 60vh;
+}
+
+.conflict-description {
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.conflict-version-info {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--surface-color);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+
+.conflict-section {
+  margin-bottom: 16px;
+}
+
+.conflict-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.conflict-section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 4px 0;
+  width: 100%;
+  text-align: left;
+}
+
+.conflict-section-toggle:hover {
+  color: var(--accent-color);
+}
+
+.conflict-toggle-icon {
+  font-size: 10px;
+  width: 14px;
+  color: var(--text-muted);
+}
+
+.conflict-diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.conflict-diff-table th {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.conflict-diff-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.conflict-field-label {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.conflict-value {
+  color: var(--text-secondary);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conflict-value--local {
+  color: var(--accent-color);
+}
+
+.conflict-value--remote {
+  color: var(--warning-color);
+}
+
+.conflict-hex-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.conflict-hex-item {
+  display: flex;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.conflict-hex-key {
+  font-family: monospace;
+  font-weight: 500;
+  color: var(--text-primary);
+  min-width: 60px;
+}
+
+.conflict-hex-detail {
+  color: var(--text-muted);
+}
+
+.conflict-auto-merged {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(76, 175, 80, 0.1);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--success-color);
+}
+
+.conflict-auto-merged-icon {
+  font-size: 14px;
 }
 
 /* Share Modal */

--- a/src/types/Sync.ts
+++ b/src/types/Sync.ts
@@ -1,0 +1,39 @@
+// Sync types — Data structures for offline-first conflict detection and resolution.
+
+import type { Campaign, Hex } from './Campaign';
+
+/** A single field that differs between local and remote versions. */
+export interface FieldDiff<T = unknown> {
+  field: string;
+  label: string;
+  localValue: T;
+  remoteValue: T;
+}
+
+/** A hex that was modified on both local and remote since the last sync. */
+export interface HexConflict {
+  hexKey: string;
+  localHex: Hex;
+  remoteHex: Hex;
+}
+
+/** Full conflict description between local and remote campaign states. */
+export interface CampaignConflict {
+  campaignId: string;
+  localVersion: number;
+  remoteVersion: number;
+  localCampaign: Campaign;
+  remoteCampaign: Campaign;
+  /** Campaign metadata fields that differ between local and remote. */
+  metadataDiffs: FieldDiff[];
+  /** Hexes modified on both sides — require user resolution. */
+  hexConflicts: HexConflict[];
+  /** Hex keys with non-overlapping changes — auto-merged without user input. */
+  autoMergedHexKeys: string[];
+}
+
+/** User's choice for resolving a conflict. */
+export type ConflictResolution =
+  | { strategy: 'keep-local' }
+  | { strategy: 'keep-remote' }
+  | { strategy: 'manual'; resolvedCampaign: Campaign };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,4 +4,5 @@ export * from './LayerVisibility';
 export * from './MapExport';
 export * from './Markers';
 export * from './Quest';
+export * from './Sync';
 export * from './Weather';

--- a/supabase/migrations/004_version_checked_upsert.sql
+++ b/supabase/migrations/004_version_checked_upsert.sql
@@ -1,0 +1,161 @@
+-- 004_version_checked_upsert.sql
+-- Atomic version-checked campaign upsert for optimistic concurrency control.
+-- Prevents last-write-wins by comparing the client's expected version against
+-- the server's current version before allowing the write.
+
+-- ============================================================================
+-- UPSERT CAMPAIGN WITH VERSION CHECK
+-- ============================================================================
+
+-- Accepts the full campaign payload plus an expected_version.
+-- If the row doesn't exist, inserts it with version = 1.
+-- If the row exists and current version != expected_version, returns conflict.
+-- If versions match, updates the row and increments version.
+-- Returns JSON: { conflict: bool, new_version?: int, server_version?: int }
+CREATE OR REPLACE FUNCTION public.upsert_campaign_versioned(
+  p_id                uuid,
+  p_owner_id          uuid,
+  p_name              text,
+  p_grid_width        int,
+  p_grid_height       int,
+  p_terrain_types     jsonb,
+  p_encounter_tables  jsonb,
+  p_time_weather      jsonb,
+  p_marker_types      jsonb,
+  p_encounter_templates jsonb,
+  p_bookmarked_hexes  jsonb,
+  p_generation_config jsonb,
+  p_landmark_tables   jsonb,
+  p_factions          jsonb,
+  p_sessions          jsonb,
+  p_session_log       jsonb,
+  p_schema_version    int,
+  p_expected_version  int,
+  p_last_modified_by  uuid,
+  p_hex_rows          jsonb DEFAULT '[]',
+  p_region_rows       jsonb DEFAULT '[]'
+)
+RETURNS jsonb AS $$
+DECLARE
+  v_current_version int;
+  v_new_version     int;
+  v_user_id         uuid;
+  v_hex             jsonb;
+  v_region          jsonb;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  -- Lock the campaign row (or detect absence)
+  SELECT version INTO v_current_version
+  FROM public.campaigns
+  WHERE id = p_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    -- New campaign — insert with version 1
+    INSERT INTO public.campaigns (
+      id, owner_id, name, grid_width, grid_height,
+      terrain_types, encounter_tables, time_weather, marker_types,
+      encounter_templates, bookmarked_hexes, generation_config,
+      landmark_tables, factions, sessions, session_log,
+      schema_version, version, last_modified_by
+    ) VALUES (
+      p_id, p_owner_id, p_name, p_grid_width, p_grid_height,
+      p_terrain_types, p_encounter_tables, p_time_weather, p_marker_types,
+      p_encounter_templates, p_bookmarked_hexes, p_generation_config,
+      p_landmark_tables, p_factions, p_sessions, p_session_log,
+      p_schema_version, 1, p_last_modified_by
+    );
+
+    -- Insert hexes
+    FOR v_hex IN SELECT * FROM jsonb_array_elements(p_hex_rows)
+    LOOP
+      INSERT INTO public.hexes (campaign_id, hex_key, data, version)
+      VALUES (p_id, v_hex->>'hex_key', v_hex->'data', 1)
+      ON CONFLICT (campaign_id, hex_key) DO UPDATE
+        SET data = EXCLUDED.data, version = 1;
+    END LOOP;
+
+    -- Insert regions
+    FOR v_region IN SELECT * FROM jsonb_array_elements(p_region_rows)
+    LOOP
+      INSERT INTO public.regions (campaign_id, name, color, description, hex_keys, tags, is_discovered, notes)
+      VALUES (
+        p_id,
+        COALESCE(v_region->>'name', ''),
+        COALESCE(v_region->>'color', '#888888'),
+        COALESCE(v_region->>'description', ''),
+        COALESCE(v_region->'hexKeys', '[]'),
+        COALESCE(v_region->'tags', '[]'),
+        COALESCE((v_region->>'isDiscovered')::boolean, false),
+        COALESCE(v_region->>'notes', '')
+      );
+    END LOOP;
+
+    RETURN jsonb_build_object('conflict', false, 'new_version', 1);
+  END IF;
+
+  -- Row exists — check version
+  IF v_current_version != p_expected_version THEN
+    RETURN jsonb_build_object(
+      'conflict', true,
+      'server_version', v_current_version
+    );
+  END IF;
+
+  -- Version matches — update
+  v_new_version := v_current_version + 1;
+
+  UPDATE public.campaigns SET
+    name = p_name,
+    grid_width = p_grid_width,
+    grid_height = p_grid_height,
+    terrain_types = p_terrain_types,
+    encounter_tables = p_encounter_tables,
+    time_weather = p_time_weather,
+    marker_types = p_marker_types,
+    encounter_templates = p_encounter_templates,
+    bookmarked_hexes = p_bookmarked_hexes,
+    generation_config = p_generation_config,
+    landmark_tables = p_landmark_tables,
+    factions = p_factions,
+    sessions = p_sessions,
+    session_log = p_session_log,
+    schema_version = p_schema_version,
+    version = v_new_version,
+    last_modified_by = p_last_modified_by
+  WHERE id = p_id;
+
+  -- Upsert hexes
+  FOR v_hex IN SELECT * FROM jsonb_array_elements(p_hex_rows)
+  LOOP
+    INSERT INTO public.hexes (campaign_id, hex_key, data, version)
+    VALUES (p_id, v_hex->>'hex_key', v_hex->'data', v_new_version)
+    ON CONFLICT (campaign_id, hex_key) DO UPDATE
+      SET data = EXCLUDED.data, version = v_new_version;
+  END LOOP;
+
+  -- Replace regions: delete existing, insert new
+  DELETE FROM public.regions WHERE campaign_id = p_id;
+
+  FOR v_region IN SELECT * FROM jsonb_array_elements(p_region_rows)
+  LOOP
+    INSERT INTO public.regions (campaign_id, name, color, description, hex_keys, tags, is_discovered, notes)
+    VALUES (
+      p_id,
+      COALESCE(v_region->>'name', ''),
+      COALESCE(v_region->>'color', '#888888'),
+      COALESCE(v_region->>'description', ''),
+      COALESCE(v_region->'hexKeys', '[]'),
+      COALESCE(v_region->'tags', '[]'),
+      COALESCE((v_region->>'isDiscovered')::boolean, false),
+      COALESCE(v_region->>'notes', '')
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object('conflict', false, 'new_version', v_new_version);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Adds optimistic concurrency control using `campaign.version` monotonic counter with server-side version checking via new Supabase RPC (`upsert_campaign_versioned`)
- Overhauls SyncEngine with version-checked saves, conflict detection, queue coalescing before replay, and retry logic for non-conflict errors
- Introduces conflict resolution UI (ConflictResolutionModal) showing metadata diffs, hex conflicts, auto-merged hexes, with Keep Mine / Keep Theirs resolution
- Wires ConnectionStatus to SyncContext for real-time sync state display (synced/syncing/offline with pending count/conflict/error)

## Key Changes
**New files:**
- `src/types/Sync.ts` — FieldDiff, HexConflict, CampaignConflict, ConflictResolution types
- `src/services/conflictResolver.ts` — hex-level diffing with auto-merge for non-overlapping changes
- `src/stores/SyncContext.tsx` — React context wrapping SyncEngine
- `src/components/modals/ConflictResolutionModal.tsx` — conflict resolution UI
- `supabase/migrations/004_version_checked_upsert.sql` — atomic version-checked RPC with FOR UPDATE row lock

**Modified:**
- `src/services/syncEngine.ts` — major overhaul (conflict flow, coalescing, retries, reload listener)
- `src/services/cloudStorage.ts` — added `saveCloudCampaignVersioned()` RPC wrapper
- `src/services/localCache.ts` — base snapshot for 3-way diff, Dexie v2, queue count helper
- `src/services/persistence/cloudAdapter.ts` — fixed broken onRemoteChange, added per-campaign subscriptions
- `src/stores/CampaignContext.tsx` — routes autosave through SyncEngine, listens for keep-remote reload
- `src/components/ui/ConnectionStatus.tsx` — wired to SyncContext with all sync states

## Test plan
- [ ] `npx tsc --noEmit` passes (no new type errors)
- [ ] `npx vitest run` — all 487 tests pass
- [ ] Deploy migration `004_version_checked_upsert.sql` to Supabase before testing cloud sync
- [ ] Open campaign on two devices, edit same hex on both, verify conflict modal appears
- [ ] Go offline (devtools), make edits, go online — verify queue replays and coalesces
- [ ] Test Keep Mine / Keep Theirs resolution flows
- [ ] Verify ConnectionStatus shows correct states in toolbar

Closes #67