### PR TITLE
feat: email/password auth + account management (#63)

### DIFF
--- a/src/components/CampaignBrowser.tsx
+++ b/src/components/CampaignBrowser.tsx
@@ -9,6 +9,7 @@ import type { Campaign } from '../types';
 import NewCampaignModal from './modals/NewCampaignModal';
 import ConfirmDialog from './modals/ConfirmDialog';
 import LoginModal from './auth/LoginModal';
+import AccountModal from './auth/AccountModal';
 import ProfileMenu from './auth/ProfileMenu';
 import Icon from './icons/Icon';
 import { useToast } from '../stores/ToastContext';
@@ -36,6 +37,7 @@ function CampaignBrowser() {
   const [cloudCampaigns, setCloudCampaigns] = useState<CloudCampaignInfo[]>([]);
   const [showNewModal, setShowNewModal] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
+  const [showAccount, setShowAccount] = useState(false);
   const [loading, setLoading] = useState(true);
   const [cloudLoading, setCloudLoading] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<{ path: string; name: string } | null>(null);
@@ -257,7 +259,10 @@ function CampaignBrowser() {
             <p className="subtitle">D&D Hex Crawl Campaign Manager</p>
           </div>
           <div className="browser-header-auth">
-            <ProfileMenu onOpenLogin={() => setShowLogin(true)} />
+            <ProfileMenu
+              onOpenLogin={() => setShowLogin(true)}
+              onOpenAccount={() => setShowAccount(true)}
+            />
           </div>
         </div>
       </div>
@@ -394,6 +399,10 @@ function CampaignBrowser() {
 
       {showLogin && (
         <LoginModal onClose={() => setShowLogin(false)} />
+      )}
+
+      {showAccount && (
+        <AccountModal onClose={() => setShowAccount(false)} />
       )}
 
       {deleteConfirm && (

--- a/src/components/MainEditor.tsx
+++ b/src/components/MainEditor.tsx
@@ -29,6 +29,7 @@ import SessionLogModal from './modals/SessionLogModal';
 import QuestManagerModal from './modals/QuestManagerModal';
 import SettingsModal from './modals/SettingsModal';
 import LoginModal from './auth/LoginModal';
+import AccountModal from './auth/AccountModal';
 import ProfileMenu from './auth/ProfileMenu';
 import ConnectionStatus from './ui/ConnectionStatus';
 import WebServerStatus from './player/WebServerStatus';
@@ -90,6 +91,7 @@ function MainEditor({ onRegisterExport, onRegisterMapExport, onRegisterExportTem
   const [showQuestManager, setShowQuestManager] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showLogin, setShowLogin] = useState(false);
+  const [showAccount, setShowAccount] = useState(false);
   const [showCreateRegion, setShowCreateRegion] = useState(false);
   const [showExportTemplate, setShowExportTemplate] = useState(false);
   const [showFogOfWar, setShowFogOfWar] = useState(false);
@@ -518,7 +520,10 @@ function MainEditor({ onRegisterExport, onRegisterMapExport, onRegisterExportTem
           </button>
           <ConnectionStatus />
           <WebServerStatus />
-          <ProfileMenu onOpenLogin={() => setShowLogin(true)} />
+          <ProfileMenu
+            onOpenLogin={() => setShowLogin(true)}
+            onOpenAccount={() => setShowAccount(true)}
+          />
           <button className="btn btn-icon" onClick={() => setShowSettings(true)} title="Settings" aria-label="Settings">
             <Icon name="settings" size={18} />
           </button>
@@ -650,6 +655,9 @@ function MainEditor({ onRegisterExport, onRegisterMapExport, onRegisterExportTem
       )}
       {showLogin && (
         <LoginModal onClose={() => setShowLogin(false)} />
+      )}
+      {showAccount && (
+        <AccountModal onClose={() => setShowAccount(false)} />
       )}
       {showCreateRegion && multiSelectedKeys.size > 0 && (
         <CreateRegionFromSelectionModal

--- a/src/components/auth/AccountModal.tsx
+++ b/src/components/auth/AccountModal.tsx
@@ -1,0 +1,58 @@
+// AccountModal — Wraps Clerk <UserProfile /> for account management
+// (change password, manage emails, active sessions, delete account).
+
+import { UserProfile } from '@clerk/react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import Icon from '../icons/Icon';
+
+interface AccountModalProps {
+  onClose: () => void;
+}
+
+const darkAppearance = {
+  variables: {
+    colorBackground: '#1e1e1e',
+    colorInputBackground: '#2a2a2a',
+    colorText: '#e0e0e0',
+    colorTextSecondary: '#a0a0a0',
+    colorPrimary: '#4a9eff',
+    colorInputText: '#e0e0e0',
+    colorNeutral: '#3a3a3a',
+    borderRadius: '6px',
+  },
+} as const;
+
+function AccountModal({ onClose }: AccountModalProps) {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+
+  return (
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="account-modal-title"
+      onClick={onClose}
+    >
+      <div
+        ref={focusTrapRef}
+        className="modal account-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h3 id="account-modal-title">
+            <Icon name="user" size={18} /> Account Settings
+          </h3>
+          <button className="close-btn" onClick={onClose} aria-label="Close">
+            x
+          </button>
+        </div>
+
+        <div className="modal-body account-modal-body">
+          <UserProfile appearance={darkAppearance} routing="hash" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AccountModal;

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -1,13 +1,23 @@
-// LoginModal — OAuth sign-in modal (Google, GitHub, Apple)
+// LoginModal — Email/password + OAuth sign-in
+// Tabs: Email (sign-in / sign-up / forgot) and OAuth (Google, GitHub, Apple).
 
 import { useState } from 'react';
-import { useSignIn } from '@clerk/react';
+import { useSignIn, useSignUp } from '@clerk/react';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import Icon from '../icons/Icon';
 
 interface LoginModalProps {
   onClose: () => void;
 }
+
+type AuthTab = 'email' | 'oauth';
+type EmailMode =
+  | 'signin'
+  | 'signup'
+  | 'signup-verify'
+  | 'forgot'
+  | 'forgot-verify'
+  | 'forgot-reset';
 
 type OAuthStrategy = 'oauth_google' | 'oauth_github' | 'oauth_apple';
 
@@ -20,17 +30,37 @@ const providers: { strategy: OAuthStrategy; label: string; icon: string }[] = [
 function LoginModal({ onClose }: LoginModalProps) {
   const focusTrapRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
   const { signIn } = useSignIn();
+  const { signUp } = useSignUp();
+
+  const [tab, setTab] = useState<AuthTab>('email');
+  const [mode, setMode] = useState<EmailMode>('signin');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  const resetState = () => {
+    setError('');
+    setCode('');
+    setPassword('');
+  };
+
+  const errorMessage = (e: unknown, fallback: string): string => {
+    if (e && typeof e === 'object' && 'message' in e) {
+      const m = (e as { message?: string }).message;
+      if (m) return m;
+    }
+    return fallback;
+  };
+
+  // -------- OAuth --------
+
   const handleOAuth = async (strategy: OAuthStrategy) => {
     if (!signIn) return;
-
     setError('');
     setSubmitting(true);
     try {
-      // Open OAuth in a popup window instead of redirecting the Electron main window.
-      // Clerk v6 natively supports a `popup` param on signIn.sso().
       const popup = window.open('about:blank', '_blank', 'width=500,height=700');
       if (!popup) {
         throw new Error('Could not open popup window. Check your popup blocker settings.');
@@ -42,13 +72,8 @@ function LoginModal({ onClose }: LoginModalProps) {
         redirectUrl: `${window.location.origin}/sso-callback`,
         redirectCallbackUrl: '/',
       });
+      if (ssoError) throw new Error(ssoError.message ?? 'SSO authentication failed');
 
-      if (ssoError) {
-        throw new Error(ssoError.message ?? 'SSO authentication failed');
-      }
-
-      // signIn.sso() with popup resolves once the OAuth flow completes.
-      // If sign-in is complete, finalize it to set the active session.
       if (signIn.status === 'complete') {
         await signIn.finalize();
         onClose();
@@ -56,52 +81,410 @@ function LoginModal({ onClose }: LoginModalProps) {
         setSubmitting(false);
       }
     } catch (err) {
-      setError('Sign-in failed. Please try again.');
+      setError(errorMessage(err, 'Sign-in failed. Please try again.'));
       console.error('OAuth error:', err);
       setSubmitting(false);
     }
   };
 
+  // -------- Sign in --------
+
+  const handleSignIn = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signIn || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: pwError } = await signIn.password({ identifier: email, password });
+      if (pwError) throw pwError;
+
+      if (signIn.status === 'complete') {
+        await signIn.finalize();
+        onClose();
+      } else {
+        setError('Additional verification is required. Please complete sign-in via OAuth.');
+      }
+    } catch (err) {
+      setError(errorMessage(err, 'Invalid email or password.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // -------- Sign up --------
+
+  const handleSignUpStart = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signUp || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: pwError } = await signUp.password({ emailAddress: email, password });
+      if (pwError) throw pwError;
+
+      const { error: sendError } = await signUp.verifications.sendEmailCode();
+      if (sendError) throw sendError;
+
+      setMode('signup-verify');
+    } catch (err) {
+      setError(errorMessage(err, 'Could not create account. Please check your email and password.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSignUpVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signUp || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: vErr } = await signUp.verifications.verifyEmailCode({ code });
+      if (vErr) throw vErr;
+
+      if (signUp.status === 'complete') {
+        await signUp.finalize();
+        onClose();
+      } else {
+        setError('Verification incomplete. Please try again.');
+      }
+    } catch (err) {
+      setError(errorMessage(err, 'Invalid or expired code.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // -------- Forgot password --------
+
+  const handleForgotStart = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signIn || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: createError } = await signIn.create({ identifier: email });
+      if (createError) throw createError;
+
+      const { error: sendError } = await signIn.resetPasswordEmailCode.sendCode();
+      if (sendError) throw sendError;
+
+      setMode('forgot-verify');
+    } catch (err) {
+      setError(errorMessage(err, 'Could not send reset code. Check the email and try again.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleForgotVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signIn || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: vErr } = await signIn.resetPasswordEmailCode.verifyCode({ code });
+      if (vErr) throw vErr;
+      setMode('forgot-reset');
+    } catch (err) {
+      setError(errorMessage(err, 'Invalid or expired code.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleForgotReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!signIn || submitting) return;
+    setError('');
+    setSubmitting(true);
+    try {
+      const { error: rErr } = await signIn.resetPasswordEmailCode.submitPassword({ password });
+      if (rErr) throw rErr;
+
+      if (signIn.status === 'complete') {
+        await signIn.finalize();
+        onClose();
+      } else {
+        setError('Password reset incomplete. Please try again.');
+      }
+    } catch (err) {
+      setError(errorMessage(err, 'Could not reset password.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // -------- Render helpers --------
+
+  const switchMode = (next: EmailMode) => {
+    resetState();
+    setMode(next);
+  };
+
+  const renderEmailTab = () => {
+    switch (mode) {
+      case 'signin':
+        return (
+          <form onSubmit={handleSignIn} className="auth-form">
+            <label className="auth-field">
+              <span>Email</span>
+              <input
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </label>
+            <label className="auth-field">
+              <span>Password</span>
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Signing in...' : 'Sign in'}
+            </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('forgot')}>
+                Forgot password?
+              </button>
+              <button type="button" className="auth-link" onClick={() => switchMode('signup')}>
+                Create account
+              </button>
+            </div>
+          </form>
+        );
+
+      case 'signup':
+        return (
+          <form onSubmit={handleSignUpStart} className="auth-form">
+            <label className="auth-field">
+              <span>Email</span>
+              <input
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </label>
+            <label className="auth-field">
+              <span>Password</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Creating account...' : 'Create account'}
+            </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('signin')}>
+                Already have an account? Sign in
+              </button>
+            </div>
+          </form>
+        );
+
+      case 'signup-verify':
+        return (
+          <form onSubmit={handleSignUpVerify} className="auth-form">
+            <p className="auth-hint">
+              We sent a 6-digit code to <strong>{email}</strong>.
+            </p>
+            <label className="auth-field">
+              <span>Verification code</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                required
+                maxLength={6}
+                autoFocus
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Verifying...' : 'Verify & sign in'}
+            </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('signup')}>
+                Back
+              </button>
+            </div>
+          </form>
+        );
+
+      case 'forgot':
+        return (
+          <form onSubmit={handleForgotStart} className="auth-form">
+            <p className="auth-hint">Enter your email — we'll send a reset code.</p>
+            <label className="auth-field">
+              <span>Email</span>
+              <input
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Sending...' : 'Send reset code'}
+            </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('signin')}>
+                Back to sign in
+              </button>
+            </div>
+          </form>
+        );
+
+      case 'forgot-verify':
+        return (
+          <form onSubmit={handleForgotVerify} className="auth-form">
+            <p className="auth-hint">
+              Enter the code we sent to <strong>{email}</strong>.
+            </p>
+            <label className="auth-field">
+              <span>Verification code</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                required
+                maxLength={6}
+                autoFocus
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Verifying...' : 'Verify code'}
+            </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('forgot')}>
+                Back
+              </button>
+            </div>
+          </form>
+        );
+
+      case 'forgot-reset':
+        return (
+          <form onSubmit={handleForgotReset} className="auth-form">
+            <label className="auth-field">
+              <span>New password</span>
+              <input
+                type="password"
+                autoComplete="new-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                minLength={8}
+                autoFocus
+              />
+            </label>
+            <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
+              {submitting ? 'Saving...' : 'Set password & sign in'}
+            </button>
+          </form>
+        );
+    }
+  };
+
+  const renderOAuthTab = () => (
+    <div className="oauth-buttons-vertical">
+      {providers.map(({ strategy, label, icon }) => (
+        <button
+          key={strategy}
+          className="oauth-btn-large"
+          onClick={() => handleOAuth(strategy)}
+          disabled={submitting}
+        >
+          <Icon name={icon as any} size={16} />
+          {submitting ? 'Signing in...' : label}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
-    <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="login-modal-title" onClick={onClose}>
+    <div
+      className="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="login-modal-title"
+      onClick={onClose}
+    >
       <div
         ref={focusTrapRef}
         className="modal login-modal"
         onClick={(e) => e.stopPropagation()}
-        style={{ width: 360 }}
+        style={{ width: 380 }}
       >
         <div className="modal-header">
           <h3 id="login-modal-title">
             <Icon name="user" size={18} /> Sign In
           </h3>
-          <button className="close-btn" onClick={onClose} aria-label="Close">x</button>
+          <button className="close-btn" onClick={onClose} aria-label="Close">
+            x
+          </button>
         </div>
 
         <div className="modal-body">
-          {error && <div className="auth-error">{error}</div>}
-
-          <div className="oauth-buttons-vertical">
-            {providers.map(({ strategy, label, icon }) => (
-              <button
-                key={strategy}
-                className="oauth-btn-large"
-                onClick={() => handleOAuth(strategy)}
-                disabled={submitting}
-              >
-                <Icon name={icon as any} size={16} />
-                {submitting ? 'Signing in...' : label}
-              </button>
-            ))}
+          <div className="auth-tabs" role="tablist">
+            <button
+              role="tab"
+              aria-selected={tab === 'email'}
+              className={`auth-tab ${tab === 'email' ? 'active' : ''}`}
+              onClick={() => {
+                setTab('email');
+                resetState();
+              }}
+            >
+              Email
+            </button>
+            <button
+              role="tab"
+              aria-selected={tab === 'oauth'}
+              className={`auth-tab ${tab === 'oauth' ? 'active' : ''}`}
+              onClick={() => {
+                setTab('oauth');
+                resetState();
+              }}
+            >
+              OAuth
+            </button>
           </div>
 
+          {error && <div className="auth-error">{error}</div>}
+
+          {tab === 'email' ? renderEmailTab() : renderOAuthTab()}
+
           <p className="auth-hint">
-            Sign in to sync campaigns across devices.
-            The app works fully offline without an account.
+            Sign in to sync campaigns across devices. The app works fully offline without an account.
           </p>
         </div>
 
         <div className="modal-footer">
-          <button className="btn btn-secondary" onClick={onClose}>Close</button>
+          <button className="btn btn-secondary" onClick={onClose}>
+            Close
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -60,8 +60,9 @@ function LoginModal({ onClose }: LoginModalProps) {
     if (!signIn) return;
     setError('');
     setSubmitting(true);
+    let popup: Window | null = null;
     try {
-      const popup = window.open('about:blank', '_blank', 'width=500,height=700');
+      popup = window.open('about:blank', '_blank', 'width=500,height=700');
       if (!popup) {
         throw new Error('Could not open popup window. Check your popup blocker settings.');
       }
@@ -78,12 +79,15 @@ function LoginModal({ onClose }: LoginModalProps) {
         await signIn.finalize();
         onClose();
       } else {
+        setError('Additional verification required. Try a different method.');
         setSubmitting(false);
       }
     } catch (err) {
       setError(errorMessage(err, 'Sign-in failed. Please try again.'));
       console.error('OAuth error:', err);
       setSubmitting(false);
+    } finally {
+      if (popup && !popup.closed) popup.close();
     }
   };
 
@@ -102,7 +106,9 @@ function LoginModal({ onClose }: LoginModalProps) {
         await signIn.finalize();
         onClose();
       } else {
-        setError('Additional verification is required. Please complete sign-in via OAuth.');
+        setError(
+          'Additional verification is required to complete sign-in. Manage 2FA in your account settings.'
+        );
       }
     } catch (err) {
       setError(errorMessage(err, 'Invalid email or password.'));
@@ -220,6 +226,12 @@ function LoginModal({ onClose }: LoginModalProps) {
   const switchMode = (next: EmailMode) => {
     resetState();
     setMode(next);
+  };
+
+  const switchTab = (next: AuthTab) => {
+    setTab(next);
+    setMode('signin');
+    resetState();
   };
 
   const renderEmailTab = () => {
@@ -402,8 +414,19 @@ function LoginModal({ onClose }: LoginModalProps) {
             <button className="btn btn-primary auth-submit" type="submit" disabled={submitting}>
               {submitting ? 'Saving...' : 'Set password & sign in'}
             </button>
+            <div className="auth-links">
+              <button type="button" className="auth-link" onClick={() => switchMode('signin')}>
+                Back to sign in
+              </button>
+            </div>
           </form>
         );
+
+      default: {
+        const _exhaustive: never = mode;
+        void _exhaustive;
+        return null;
+      }
     }
   };
 
@@ -452,10 +475,7 @@ function LoginModal({ onClose }: LoginModalProps) {
               role="tab"
               aria-selected={tab === 'email'}
               className={`auth-tab ${tab === 'email' ? 'active' : ''}`}
-              onClick={() => {
-                setTab('email');
-                resetState();
-              }}
+              onClick={() => switchTab('email')}
             >
               Email
             </button>
@@ -463,10 +483,7 @@ function LoginModal({ onClose }: LoginModalProps) {
               role="tab"
               aria-selected={tab === 'oauth'}
               className={`auth-tab ${tab === 'oauth' ? 'active' : ''}`}
-              onClick={() => {
-                setTab('oauth');
-                resetState();
-              }}
+              onClick={() => switchTab('oauth')}
             >
               OAuth
             </button>

--- a/src/components/auth/ProfileMenu.tsx
+++ b/src/components/auth/ProfileMenu.tsx
@@ -6,7 +6,7 @@ import Icon from '../icons/Icon';
 
 interface ProfileMenuProps {
   onOpenLogin: () => void;
-  onOpenAccount?: () => void;
+  onOpenAccount: () => void;
 }
 
 // Deterministic color from display name for avatar circle
@@ -75,18 +75,16 @@ function ProfileMenu({ onOpenLogin, onOpenAccount }: ProfileMenuProps) {
           <div className="profile-dropdown-name">{user.displayName}</div>
           <div className="profile-dropdown-email">{user.email}</div>
           <div className="profile-dropdown-divider" />
-          {onOpenAccount && (
-            <button
-              className="btn btn-secondary"
-              onClick={() => {
-                setOpen(false);
-                onOpenAccount();
-              }}
-              style={{ width: '100%', fontSize: 12, padding: '6px 8px', marginBottom: 4 }}
-            >
-              Account settings
-            </button>
-          )}
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              setOpen(false);
+              onOpenAccount();
+            }}
+            style={{ width: '100%', fontSize: 12, padding: '6px 8px', marginBottom: 4 }}
+          >
+            Account settings
+          </button>
           <button
             className="btn btn-secondary"
             onClick={handleSignOut}

--- a/src/components/auth/ProfileMenu.tsx
+++ b/src/components/auth/ProfileMenu.tsx
@@ -6,6 +6,7 @@ import Icon from '../icons/Icon';
 
 interface ProfileMenuProps {
   onOpenLogin: () => void;
+  onOpenAccount?: () => void;
 }
 
 // Deterministic color from display name for avatar circle
@@ -21,7 +22,7 @@ function avatarColor(name: string): string {
   return colors[Math.abs(hash) % colors.length];
 }
 
-function ProfileMenu({ onOpenLogin }: ProfileMenuProps) {
+function ProfileMenu({ onOpenLogin, onOpenAccount }: ProfileMenuProps) {
   const { user, isAuthenticated, signOut } = useAuth();
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -74,6 +75,18 @@ function ProfileMenu({ onOpenLogin }: ProfileMenuProps) {
           <div className="profile-dropdown-name">{user.displayName}</div>
           <div className="profile-dropdown-email">{user.email}</div>
           <div className="profile-dropdown-divider" />
+          {onOpenAccount && (
+            <button
+              className="btn btn-secondary"
+              onClick={() => {
+                setOpen(false);
+                onOpenAccount();
+              }}
+              style={{ width: '100%', fontSize: 12, padding: '6px 8px', marginBottom: 4 }}
+            >
+              Account settings
+            </button>
+          )}
           <button
             className="btn btn-secondary"
             onClick={handleSignOut}

--- a/src/styles/auth.css
+++ b/src/styles/auth.css
@@ -48,6 +48,115 @@
   line-height: 1.4;
 }
 
+/* Login Modal — Email/password forms */
+
+.login-modal .auth-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.login-modal .auth-tab {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  padding: 8px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.login-modal .auth-tab:hover {
+  color: var(--text-primary);
+}
+
+.login-modal .auth-tab.active {
+  color: var(--accent-color);
+  border-bottom-color: var(--accent-color);
+}
+
+.login-modal .auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-modal .auth-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.login-modal .auth-field span {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.login-modal .auth-field input {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 8px 10px;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.login-modal .auth-field input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.login-modal .auth-submit {
+  margin-top: 4px;
+  width: 100%;
+}
+
+.login-modal .auth-links {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.login-modal .auth-link {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 4px 0;
+  text-decoration: underline;
+}
+
+.login-modal .auth-link:hover {
+  color: var(--accent-color);
+}
+
+/* Account Modal — Clerk UserProfile wrapper */
+
+.account-modal {
+  width: min(880px, 96vw);
+  max-height: 90vh;
+}
+
+.account-modal .account-modal-body {
+  padding: 0;
+  overflow: auto;
+  max-height: calc(90vh - 56px);
+}
+
+.account-modal .account-modal-body .cl-rootBox,
+.account-modal .account-modal-body .cl-card {
+  width: 100%;
+  box-shadow: none;
+  background: transparent;
+}
+
 /* Profile Menu */
 
 .profile-menu {


### PR DESCRIPTION
## Summary
- Extends `LoginModal` with a tabbed UI (Email | OAuth). Email tab supports password sign-in, sign-up with email-code verification, and forgot-password reset, all via Clerk's signal-based `useSignIn` / `useSignUp` hooks.
- Adds `AccountModal` wrapping Clerk `<UserProfile />` for change password, manage emails, active sessions, and account deletion. Reachable from `ProfileMenu` -> "Account settings".
- Existing OAuth (Google/GitHub/Apple) flow and the Clerk -> Supabase JWT bridge are unchanged. `AuthContext`, `supabaseClient`, and Supabase RLS policies need no modifications.

Closes #63.

## Prerequisite (Clerk dashboard)
Enable in the Clerk dashboard so the new flows can complete:
- Email address (required)
- Password (required)
- Email verification code

OAuth providers stay enabled.

## Test plan
- [ ] **Sign-up**: Sign In -> Email tab -> "Create account" -> email + password -> 6-digit code -> session active.
- [ ] **Sign-in**: email + password -> session active.
- [ ] **Forgot password**: send code -> verify -> set new password -> session active.
- [ ] **OAuth regression**: Google / GitHub / Apple still work.
- [ ] **Account settings**: change password, then sign out/in with the new password.
- [ ] **Delete account**: throwaway account -> delete -> session cleared, no further authenticated Supabase requests.
- [ ] **Cloud sync**: with Supabase configured, RLS-gated reads/writes succeed for an email/password user.
- [ ] **No-Clerk fallback**: unset `VITE_CLERK_PUBLISHABLE_KEY` -> app loads in offline mode without auth UI errors.
- [ ] `npx tsc --noEmit` and `npx vitest run` pass (487 tests green locally).